### PR TITLE
fix(go/cli): decode pagination key from base64

### DIFF
--- a/go/cli/audit_query.go
+++ b/go/cli/audit_query.go
@@ -35,7 +35,7 @@ func GetAuditProvidersCmd() *cobra.Command {
 			ctx := cmd.Context()
 			cl := MustLightClientFromContext(ctx)
 
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}

--- a/go/cli/cert_query.go
+++ b/go/cli/cert_query.go
@@ -39,7 +39,7 @@ func GetQueryCertCertificatesCmd() *cobra.Command {
 			ctx := cmd.Context()
 			cl := MustLightClientFromContext(ctx)
 
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}

--- a/go/cli/deployment_query.go
+++ b/go/cli/deployment_query.go
@@ -44,7 +44,7 @@ func GetQueryDeploymentsCmd() *cobra.Command {
 				return err
 			}
 
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}

--- a/go/cli/market_query.go
+++ b/go/cli/market_query.go
@@ -90,7 +90,7 @@ func GetQueryMarketOrdersCmd() *cobra.Command {
 				return err
 			}
 
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -162,7 +162,7 @@ func GetQueryMarketBidsCmd() *cobra.Command {
 				return err
 			}
 
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -233,7 +233,7 @@ func GetQueryMarketLeasesCmd() *cobra.Command {
 				return err
 			}
 
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}

--- a/go/cli/provider_query.go
+++ b/go/cli/provider_query.go
@@ -36,7 +36,7 @@ func GetQueryProvidersCmd() *cobra.Command {
 			ctx := cmd.Context()
 			cl := MustLightClientFromContext(ctx)
 
-			pageReq, err := sdkclient.ReadPageRequest(cmd.Flags())
+			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
when marshaling query outbut bytestream data is being encoded using base64. ReadPageRequest does not account for this and passes base64 encoded next key to the query

## 🌟 PR Title
[Use a clear, concise title that reflects the change]

## 📝 Description
[Explain what this PR does in 2-3 sentences. Include context about the feature or problem being solved]

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [ ] Code follows Akash Network's style guide
- [ ] I've added/updated relevant unit tests
- [ ] Dependencies have been properly updated
- [ ] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
