### PR TITLE
feat: add base mock for transactions

### DIFF
--- a/mock/node/data/audit_tx.json
+++ b/mock/node/data/audit_tx.json
@@ -1,0 +1,8 @@
+{
+  "sign_provider_attributes_responses": [
+    {}
+  ],
+  "delete_provider_attributes_responses": [
+    {}
+  ]
+}

--- a/mock/node/data/cert_tx.json
+++ b/mock/node/data/cert_tx.json
@@ -1,0 +1,8 @@
+{
+  "create_certificate_responses": [
+    {}
+  ],
+  "revoke_certificate_responses": [
+    {}
+  ]
+}

--- a/mock/node/data/deployment_tx.json
+++ b/mock/node/data/deployment_tx.json
@@ -1,0 +1,11 @@
+{
+  "create_deployment_responses": [
+    {}
+  ],
+  "update_deployment_responses": [
+    {}
+  ],
+  "close_deployment_responses": [
+    {}
+  ]
+}

--- a/mock/node/data/escrow_tx.json
+++ b/mock/node/data/escrow_tx.json
@@ -1,0 +1,5 @@
+{
+  "account_deposit_responses": [
+    {}
+  ]
+}

--- a/mock/node/data/market_tx.json
+++ b/mock/node/data/market_tx.json
@@ -1,0 +1,17 @@
+{
+  "create_bid_responses": [
+    {}
+  ],
+  "close_bid_responses": [
+    {}
+  ],
+  "withdraw_lease_responses": [
+    {}
+  ],
+  "create_lease_responses": [
+    {}
+  ],
+  "close_lease_responses": [
+    {}
+  ]
+}

--- a/mock/node/data/provider_tx.json
+++ b/mock/node/data/provider_tx.json
@@ -1,0 +1,11 @@
+{
+  "create_provider_responses": [
+    {}
+  ],
+  "update_provider_responses": [
+    {}
+  ],
+  "delete_provider_responses": [
+    {}
+  ]
+}

--- a/mock/node/data/staking_tx.json
+++ b/mock/node/data/staking_tx.json
@@ -1,0 +1,5 @@
+{
+  "update_params_responses": [
+    {}
+  ]
+}

--- a/mock/node/data/take_tx.json
+++ b/mock/node/data/take_tx.json
@@ -1,0 +1,5 @@
+{
+  "update_params_responses": [
+    {}
+  ]
+}

--- a/mock/node/main.go
+++ b/mock/node/main.go
@@ -14,10 +14,10 @@ import (
 	"syscall"
 	"time"
 
+	feegrantv1beta1 "cosmossdk.io/x/feegrant"
 	authv1beta1 "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authzv1beta1 "github.com/cosmos/cosmos-sdk/x/authz"
 	bankv1beta1 "github.com/cosmos/cosmos-sdk/x/bank/types"
-	feegrantv1beta1 "cosmossdk.io/x/feegrant"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	_ "k8s.io/apimachinery/pkg/api/resource"
@@ -69,6 +69,30 @@ var BankData string
 //go:embed data/feegrant.json
 var FeegrantData string
 
+//go:embed data/deployment_tx.json
+var DeploymentTxData string
+
+//go:embed data/market_tx.json
+var MarketTxData string
+
+//go:embed data/escrow_tx.json
+var EscrowTxData string
+
+//go:embed data/cert_tx.json
+var CertTxData string
+
+//go:embed data/provider_tx.json
+var ProviderTxData string
+
+//go:embed data/audit_tx.json
+var AuditTxData string
+
+//go:embed data/take_tx.json
+var TakeTxData string
+
+//go:embed data/staking_tx.json
+var StakingTxData string
+
 // StaticDeployments holds the deployments loaded from JSON
 var StaticDeployments []deploymentv1beta4.QueryDeploymentResponse
 
@@ -105,20 +129,52 @@ var StaticBankData mocks.BankData
 // StaticFeegrantData holds the feegrant data loaded from JSON
 var StaticFeegrantData mocks.FeegrantData
 
+// StaticDeploymentTxData holds the deployment transaction data loaded from JSON
+var StaticDeploymentTxData mocks.DeploymentTxData
+
+// StaticMarketTxData holds the market transaction data loaded from JSON
+var StaticMarketTxData mocks.MarketTxData
+
+// StaticEscrowTxData holds the escrow transaction data loaded from JSON
+var StaticEscrowTxData mocks.EscrowTxData
+
+// StaticCertTxData holds the certificate transaction data loaded from JSON
+var StaticCertTxData mocks.CertTxData
+
+// StaticProviderTxData holds the provider transaction data loaded from JSON
+var StaticProviderTxData mocks.ProviderTxData
+
+// StaticAuditTxData holds the audit transaction data loaded from JSON
+var StaticAuditTxData mocks.AuditTxData
+
+// StaticTakeTxData holds the take transaction data loaded from JSON
+var StaticTakeTxData mocks.TakeTxData
+
+// StaticStakingTxData holds the staking transaction data loaded from JSON
+var StaticStakingTxData mocks.StakingTxData
+
 // embeddedData maps file names to their embedded content
 var embeddedData = map[string]string{
-	"deployments":  DeploymentsData,
-	"escrow":       EscrowData,
-	"providers":    ProvidersData,
-	"certificates": CertificatesData,
-	"market":       MarketData,
-	"audit":        AuditData,
-	"staking":      StakingData,
-	"take":         TakeData,
-	"authz":        AuthzData,
-	"auth":         AuthData,
-	"bank":         BankData,
-	"feegrant":     FeegrantData,
+	"deployments":   DeploymentsData,
+	"escrow":        EscrowData,
+	"providers":     ProvidersData,
+	"certificates":  CertificatesData,
+	"market":        MarketData,
+	"audit":         AuditData,
+	"staking":       StakingData,
+	"take":          TakeData,
+	"authz":         AuthzData,
+	"auth":          AuthData,
+	"bank":          BankData,
+	"feegrant":      FeegrantData,
+	"deployment_tx": DeploymentTxData,
+	"market_tx":     MarketTxData,
+	"escrow_tx":     EscrowTxData,
+	"cert_tx":       CertTxData,
+	"provider_tx":   ProviderTxData,
+	"audit_tx":      AuditTxData,
+	"take_tx":       TakeTxData,
+	"staking_tx":    StakingTxData,
 }
 
 func init() {
@@ -193,6 +249,54 @@ func init() {
 	if err != nil {
 		panic(fmt.Errorf("failed to unmarshal feegrant data: %w", err))
 	}
+
+	// Load deployment transaction data
+	err = json.Unmarshal([]byte(DeploymentTxData), &StaticDeploymentTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal deployment transaction data: %w", err))
+	}
+
+	// Load market transaction data
+	err = json.Unmarshal([]byte(MarketTxData), &StaticMarketTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal market transaction data: %w", err))
+	}
+
+	// Load escrow transaction data
+	err = json.Unmarshal([]byte(EscrowTxData), &StaticEscrowTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal escrow transaction data: %w", err))
+	}
+
+	// Load certificate transaction data
+	err = json.Unmarshal([]byte(CertTxData), &StaticCertTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal certificate transaction data: %w", err))
+	}
+
+	// Load provider transaction data
+	err = json.Unmarshal([]byte(ProviderTxData), &StaticProviderTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal provider transaction data: %w", err))
+	}
+
+	// Load audit transaction data
+	err = json.Unmarshal([]byte(AuditTxData), &StaticAuditTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal audit transaction data: %w", err))
+	}
+
+	// Load take transaction data
+	err = json.Unmarshal([]byte(TakeTxData), &StaticTakeTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal take transaction data: %w", err))
+	}
+
+	// Load staking transaction data
+	err = json.Unmarshal([]byte(StakingTxData), &StaticStakingTxData)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal staking transaction data: %w", err))
+	}
 }
 
 func startGRPCServer(ctx context.Context) error {
@@ -201,6 +305,38 @@ func startGRPCServer(ctx context.Context) error {
 	// Register deployment server
 	mockDeploymentQueryServer := mocks.NewMockDeploymentQueryServer(StaticDeployments)
 	deploymentv1beta4.RegisterQueryServer(grpcSrv, mockDeploymentQueryServer)
+
+	// Register deployment transaction server
+	mockDeploymentMsgServer := mocks.NewMockDeploymentMsgServer(StaticDeploymentTxData)
+	deploymentv1beta4.RegisterMsgServer(grpcSrv, mockDeploymentMsgServer)
+
+	// Register market transaction server
+	mockMarketMsgServer := mocks.NewMockMarketMsgServer(StaticMarketTxData)
+	marketv1beta5.RegisterMsgServer(grpcSrv, mockMarketMsgServer)
+
+	// Register escrow transaction server
+	mockEscrowMsgServer := mocks.NewMockEscrowMsgServer(StaticEscrowTxData)
+	escrowv1.RegisterMsgServer(grpcSrv, mockEscrowMsgServer)
+
+	// Register certificate transaction server
+	mockCertMsgServer := mocks.NewMockCertMsgServer(StaticCertTxData)
+	certv1.RegisterMsgServer(grpcSrv, mockCertMsgServer)
+
+	// Register provider transaction server
+	mockProviderMsgServer := mocks.NewMockProviderMsgServer(StaticProviderTxData)
+	providerv1beta4.RegisterMsgServer(grpcSrv, mockProviderMsgServer)
+
+	// Register audit transaction server
+	mockAuditMsgServer := mocks.NewMockAuditMsgServer(StaticAuditTxData)
+	auditv1.RegisterMsgServer(grpcSrv, mockAuditMsgServer)
+
+	// Register take transaction server
+	mockTakeMsgServer := mocks.NewMockTakeMsgServer(StaticTakeTxData)
+	takev1.RegisterMsgServer(grpcSrv, mockTakeMsgServer)
+
+	// Register staking transaction server
+	mockStakingMsgServer := mocks.NewMockStakingMsgServer(StaticStakingTxData)
+	stakingv1beta3.RegisterMsgServer(grpcSrv, mockStakingMsgServer)
 
 	// Register escrow server
 	mockEscrowQueryServer := mocks.NewMockEscrowQueryServer(StaticEscrowData)

--- a/mock/node/mocks/audit_tx.go
+++ b/mock/node/mocks/audit_tx.go
@@ -1,0 +1,44 @@
+package mocks
+
+import (
+	"context"
+
+	auditv1 "pkg.akt.dev/go/node/audit/v1"
+)
+
+// MockAuditMsgServer implements the audit message server for transactions
+type MockAuditMsgServer struct {
+	auditv1.UnimplementedMsgServer
+	SignProviderAttributesResponses   []auditv1.MsgSignProviderAttributesResponse
+	DeleteProviderAttributesResponses []auditv1.MsgDeleteProviderAttributesResponse
+}
+
+// AuditTxData holds mock data for audit transactions
+type AuditTxData struct {
+	SignProviderAttributesResponses   []auditv1.MsgSignProviderAttributesResponse   `json:"sign_provider_attributes_responses"`
+	DeleteProviderAttributesResponses []auditv1.MsgDeleteProviderAttributesResponse `json:"delete_provider_attributes_responses"`
+}
+
+// NewMockAuditMsgServer creates a new mock audit message server
+func NewMockAuditMsgServer(data AuditTxData) *MockAuditMsgServer {
+	return &MockAuditMsgServer{
+		SignProviderAttributesResponses:   data.SignProviderAttributesResponses,
+		DeleteProviderAttributesResponses: data.DeleteProviderAttributesResponses,
+	}
+}
+
+// SignProviderAttributes implements the SignProviderAttributes transaction
+func (m *MockAuditMsgServer) SignProviderAttributes(ctx context.Context, req *auditv1.MsgSignProviderAttributes) (*auditv1.MsgSignProviderAttributesResponse, error) {
+	if len(m.SignProviderAttributesResponses) == 0 {
+		return &auditv1.MsgSignProviderAttributesResponse{}, nil
+	}
+	return &m.SignProviderAttributesResponses[0], nil
+}
+
+// DeleteProviderAttributes implements the DeleteProviderAttributes transaction
+func (m *MockAuditMsgServer) DeleteProviderAttributes(ctx context.Context, req *auditv1.MsgDeleteProviderAttributes) (*auditv1.MsgDeleteProviderAttributesResponse, error) {
+	if len(m.DeleteProviderAttributesResponses) == 0 {
+		return &auditv1.MsgDeleteProviderAttributesResponse{}, nil
+	}
+	return &m.DeleteProviderAttributesResponses[0], nil
+}

--- a/mock/node/mocks/cert_tx.go
+++ b/mock/node/mocks/cert_tx.go
@@ -1,0 +1,44 @@
+package mocks
+
+import (
+	"context"
+
+	certv1 "pkg.akt.dev/go/node/cert/v1"
+)
+
+// MockCertMsgServer implements the certificate message server for transactions
+type MockCertMsgServer struct {
+	certv1.UnimplementedMsgServer
+	CreateCertificateResponses []certv1.MsgCreateCertificateResponse
+	RevokeCertificateResponses []certv1.MsgRevokeCertificateResponse
+}
+
+// CertTxData holds mock data for certificate transactions
+type CertTxData struct {
+	CreateCertificateResponses []certv1.MsgCreateCertificateResponse `json:"create_certificate_responses"`
+	RevokeCertificateResponses []certv1.MsgRevokeCertificateResponse `json:"revoke_certificate_responses"`
+}
+
+// NewMockCertMsgServer creates a new mock certificate message server
+func NewMockCertMsgServer(data CertTxData) *MockCertMsgServer {
+	return &MockCertMsgServer{
+		CreateCertificateResponses: data.CreateCertificateResponses,
+		RevokeCertificateResponses: data.RevokeCertificateResponses,
+	}
+}
+
+// CreateCertificate implements the CreateCertificate transaction
+func (m *MockCertMsgServer) CreateCertificate(ctx context.Context, req *certv1.MsgCreateCertificate) (*certv1.MsgCreateCertificateResponse, error) {
+	if len(m.CreateCertificateResponses) == 0 {
+		return &certv1.MsgCreateCertificateResponse{}, nil
+	}
+	return &m.CreateCertificateResponses[0], nil
+}
+
+// RevokeCertificate implements the RevokeCertificate transaction
+func (m *MockCertMsgServer) RevokeCertificate(ctx context.Context, req *certv1.MsgRevokeCertificate) (*certv1.MsgRevokeCertificateResponse, error) {
+	if len(m.RevokeCertificateResponses) == 0 {
+		return &certv1.MsgRevokeCertificateResponse{}, nil
+	}
+	return &m.RevokeCertificateResponses[0], nil
+}

--- a/mock/node/mocks/deployment_tx.go
+++ b/mock/node/mocks/deployment_tx.go
@@ -1,0 +1,81 @@
+package mocks
+
+import (
+	"context"
+	"fmt"
+
+	deploymentv1beta4 "pkg.akt.dev/go/node/deployment/v1beta4"
+)
+
+// MockDeploymentMsgServer implements the deployment message server for transactions
+type MockDeploymentMsgServer struct {
+	deploymentv1beta4.UnimplementedMsgServer
+	CreateDeploymentResponses []deploymentv1beta4.MsgCreateDeploymentResponse
+	UpdateDeploymentResponses []deploymentv1beta4.MsgUpdateDeploymentResponse
+	CloseDeploymentResponses  []deploymentv1beta4.MsgCloseDeploymentResponse
+}
+
+// DeploymentTxData holds mock data for deployment transactions
+type DeploymentTxData struct {
+	CreateDeploymentResponses []deploymentv1beta4.MsgCreateDeploymentResponse `json:"create_deployment_responses"`
+	UpdateDeploymentResponses []deploymentv1beta4.MsgUpdateDeploymentResponse `json:"update_deployment_responses"`
+	CloseDeploymentResponses  []deploymentv1beta4.MsgCloseDeploymentResponse  `json:"close_deployment_responses"`
+}
+
+// NewMockDeploymentMsgServer creates a new mock deployment message server
+func NewMockDeploymentMsgServer(data DeploymentTxData) *MockDeploymentMsgServer {
+	return &MockDeploymentMsgServer{
+		CreateDeploymentResponses: data.CreateDeploymentResponses,
+		UpdateDeploymentResponses: data.UpdateDeploymentResponses,
+		CloseDeploymentResponses:  data.CloseDeploymentResponses,
+	}
+}
+
+// CreateDeployment implements the CreateDeployment transaction
+func (m *MockDeploymentMsgServer) CreateDeployment(ctx context.Context, req *deploymentv1beta4.MsgCreateDeployment) (*deploymentv1beta4.MsgCreateDeploymentResponse, error) {
+	if len(m.CreateDeploymentResponses) == 0 {
+		return &deploymentv1beta4.MsgCreateDeploymentResponse{}, nil
+	}
+
+	// Return the first available response for simplicity
+	// In a more sophisticated mock, you might match based on request parameters
+	return &m.CreateDeploymentResponses[0], nil
+}
+
+// UpdateDeployment implements the UpdateDeployment transaction
+func (m *MockDeploymentMsgServer) UpdateDeployment(ctx context.Context, req *deploymentv1beta4.MsgUpdateDeployment) (*deploymentv1beta4.MsgUpdateDeploymentResponse, error) {
+	if len(m.UpdateDeploymentResponses) == 0 {
+		return &deploymentv1beta4.MsgUpdateDeploymentResponse{}, nil
+	}
+
+	return &m.UpdateDeploymentResponses[0], nil
+}
+
+// CloseDeployment implements the CloseDeployment transaction
+func (m *MockDeploymentMsgServer) CloseDeployment(ctx context.Context, req *deploymentv1beta4.MsgCloseDeployment) (*deploymentv1beta4.MsgCloseDeploymentResponse, error) {
+	if len(m.CloseDeploymentResponses) == 0 {
+		return &deploymentv1beta4.MsgCloseDeploymentResponse{}, nil
+	}
+
+	return &m.CloseDeploymentResponses[0], nil
+}
+
+// CloseGroup implements the CloseGroup transaction (not implemented for this example)
+func (m *MockDeploymentMsgServer) CloseGroup(ctx context.Context, req *deploymentv1beta4.MsgCloseGroup) (*deploymentv1beta4.MsgCloseGroupResponse, error) {
+	return nil, fmt.Errorf("CloseGroup not implemented in this mock")
+}
+
+// PauseGroup implements the PauseGroup transaction (not implemented for this example)
+func (m *MockDeploymentMsgServer) PauseGroup(ctx context.Context, req *deploymentv1beta4.MsgPauseGroup) (*deploymentv1beta4.MsgPauseGroupResponse, error) {
+	return nil, fmt.Errorf("PauseGroup not implemented in this mock")
+}
+
+// StartGroup implements the StartGroup transaction (not implemented for this example)
+func (m *MockDeploymentMsgServer) StartGroup(ctx context.Context, req *deploymentv1beta4.MsgStartGroup) (*deploymentv1beta4.MsgStartGroupResponse, error) {
+	return nil, fmt.Errorf("StartGroup not implemented in this mock")
+}
+
+// UpdateParams implements the UpdateParams transaction (not implemented for this example)
+func (m *MockDeploymentMsgServer) UpdateParams(ctx context.Context, req *deploymentv1beta4.MsgUpdateParams) (*deploymentv1beta4.MsgUpdateParamsResponse, error) {
+	return nil, fmt.Errorf("UpdateParams not implemented in this mock")
+}

--- a/mock/node/mocks/escrow_tx.go
+++ b/mock/node/mocks/escrow_tx.go
@@ -1,0 +1,33 @@
+package mocks
+
+import (
+	"context"
+
+	escrowv1 "pkg.akt.dev/go/node/escrow/v1"
+)
+
+// MockEscrowMsgServer implements the escrow message server for transactions
+type MockEscrowMsgServer struct {
+	escrowv1.UnimplementedMsgServer
+	AccountDepositResponses []escrowv1.MsgAccountDepositResponse
+}
+
+// EscrowTxData holds mock data for escrow transactions
+type EscrowTxData struct {
+	AccountDepositResponses []escrowv1.MsgAccountDepositResponse `json:"account_deposit_responses"`
+}
+
+// NewMockEscrowMsgServer creates a new mock escrow message server
+func NewMockEscrowMsgServer(data EscrowTxData) *MockEscrowMsgServer {
+	return &MockEscrowMsgServer{
+		AccountDepositResponses: data.AccountDepositResponses,
+	}
+}
+
+// AccountDeposit implements the AccountDeposit transaction
+func (m *MockEscrowMsgServer) AccountDeposit(ctx context.Context, req *escrowv1.MsgAccountDeposit) (*escrowv1.MsgAccountDepositResponse, error) {
+	if len(m.AccountDepositResponses) == 0 {
+		return &escrowv1.MsgAccountDepositResponse{}, nil
+	}
+	return &m.AccountDepositResponses[0], nil
+}

--- a/mock/node/mocks/market_tx.go
+++ b/mock/node/mocks/market_tx.go
@@ -1,0 +1,77 @@
+package mocks
+
+import (
+	"context"
+
+	marketv1beta5 "pkg.akt.dev/go/node/market/v1beta5"
+)
+
+// MockMarketMsgServer implements the market message server for transactions
+type MockMarketMsgServer struct {
+	marketv1beta5.UnimplementedMsgServer
+	CreateBidResponses     []marketv1beta5.MsgCreateBidResponse
+	CloseBidResponses      []marketv1beta5.MsgCloseBidResponse
+	WithdrawLeaseResponses []marketv1beta5.MsgWithdrawLeaseResponse
+	CreateLeaseResponses   []marketv1beta5.MsgCreateLeaseResponse
+	CloseLeaseResponses    []marketv1beta5.MsgCloseLeaseResponse
+}
+
+// MarketTxData holds mock data for market transactions
+type MarketTxData struct {
+	CreateBidResponses     []marketv1beta5.MsgCreateBidResponse     `json:"create_bid_responses"`
+	CloseBidResponses      []marketv1beta5.MsgCloseBidResponse      `json:"close_bid_responses"`
+	WithdrawLeaseResponses []marketv1beta5.MsgWithdrawLeaseResponse `json:"withdraw_lease_responses"`
+	CreateLeaseResponses   []marketv1beta5.MsgCreateLeaseResponse   `json:"create_lease_responses"`
+	CloseLeaseResponses    []marketv1beta5.MsgCloseLeaseResponse    `json:"close_lease_responses"`
+}
+
+// NewMockMarketMsgServer creates a new mock market message server
+func NewMockMarketMsgServer(data MarketTxData) *MockMarketMsgServer {
+	return &MockMarketMsgServer{
+		CreateBidResponses:     data.CreateBidResponses,
+		CloseBidResponses:      data.CloseBidResponses,
+		WithdrawLeaseResponses: data.WithdrawLeaseResponses,
+		CreateLeaseResponses:   data.CreateLeaseResponses,
+		CloseLeaseResponses:    data.CloseLeaseResponses,
+	}
+}
+
+// CreateBid implements the CreateBid transaction
+func (m *MockMarketMsgServer) CreateBid(ctx context.Context, req *marketv1beta5.MsgCreateBid) (*marketv1beta5.MsgCreateBidResponse, error) {
+	if len(m.CreateBidResponses) == 0 {
+		return &marketv1beta5.MsgCreateBidResponse{}, nil
+	}
+	return &m.CreateBidResponses[0], nil
+}
+
+// CloseBid implements the CloseBid transaction
+func (m *MockMarketMsgServer) CloseBid(ctx context.Context, req *marketv1beta5.MsgCloseBid) (*marketv1beta5.MsgCloseBidResponse, error) {
+	if len(m.CloseBidResponses) == 0 {
+		return &marketv1beta5.MsgCloseBidResponse{}, nil
+	}
+	return &m.CloseBidResponses[0], nil
+}
+
+// WithdrawLease implements the WithdrawLease transaction
+func (m *MockMarketMsgServer) WithdrawLease(ctx context.Context, req *marketv1beta5.MsgWithdrawLease) (*marketv1beta5.MsgWithdrawLeaseResponse, error) {
+	if len(m.WithdrawLeaseResponses) == 0 {
+		return &marketv1beta5.MsgWithdrawLeaseResponse{}, nil
+	}
+	return &m.WithdrawLeaseResponses[0], nil
+}
+
+// CreateLease implements the CreateLease transaction
+func (m *MockMarketMsgServer) CreateLease(ctx context.Context, req *marketv1beta5.MsgCreateLease) (*marketv1beta5.MsgCreateLeaseResponse, error) {
+	if len(m.CreateLeaseResponses) == 0 {
+		return &marketv1beta5.MsgCreateLeaseResponse{}, nil
+	}
+	return &m.CreateLeaseResponses[0], nil
+}
+
+// CloseLease implements the CloseLease transaction
+func (m *MockMarketMsgServer) CloseLease(ctx context.Context, req *marketv1beta5.MsgCloseLease) (*marketv1beta5.MsgCloseLeaseResponse, error) {
+	if len(m.CloseLeaseResponses) == 0 {
+		return &marketv1beta5.MsgCloseLeaseResponse{}, nil
+	}
+	return &m.CloseLeaseResponses[0], nil
+}

--- a/mock/node/mocks/provider_tx.go
+++ b/mock/node/mocks/provider_tx.go
@@ -1,0 +1,55 @@
+package mocks
+
+import (
+	"context"
+
+	providerv1beta4 "pkg.akt.dev/go/node/provider/v1beta4"
+)
+
+// MockProviderMsgServer implements the provider message server for transactions
+type MockProviderMsgServer struct {
+	providerv1beta4.UnimplementedMsgServer
+	CreateProviderResponses []providerv1beta4.MsgCreateProviderResponse
+	UpdateProviderResponses []providerv1beta4.MsgUpdateProviderResponse
+	DeleteProviderResponses []providerv1beta4.MsgDeleteProviderResponse
+}
+
+// ProviderTxData holds mock data for provider transactions
+type ProviderTxData struct {
+	CreateProviderResponses []providerv1beta4.MsgCreateProviderResponse `json:"create_provider_responses"`
+	UpdateProviderResponses []providerv1beta4.MsgUpdateProviderResponse `json:"update_provider_responses"`
+	DeleteProviderResponses []providerv1beta4.MsgDeleteProviderResponse `json:"delete_provider_responses"`
+}
+
+// NewMockProviderMsgServer creates a new mock provider message server
+func NewMockProviderMsgServer(data ProviderTxData) *MockProviderMsgServer {
+	return &MockProviderMsgServer{
+		CreateProviderResponses: data.CreateProviderResponses,
+		UpdateProviderResponses: data.UpdateProviderResponses,
+		DeleteProviderResponses: data.DeleteProviderResponses,
+	}
+}
+
+// CreateProvider implements the CreateProvider transaction
+func (m *MockProviderMsgServer) CreateProvider(ctx context.Context, req *providerv1beta4.MsgCreateProvider) (*providerv1beta4.MsgCreateProviderResponse, error) {
+	if len(m.CreateProviderResponses) == 0 {
+		return &providerv1beta4.MsgCreateProviderResponse{}, nil
+	}
+	return &m.CreateProviderResponses[0], nil
+}
+
+// UpdateProvider implements the UpdateProvider transaction
+func (m *MockProviderMsgServer) UpdateProvider(ctx context.Context, req *providerv1beta4.MsgUpdateProvider) (*providerv1beta4.MsgUpdateProviderResponse, error) {
+	if len(m.UpdateProviderResponses) == 0 {
+		return &providerv1beta4.MsgUpdateProviderResponse{}, nil
+	}
+	return &m.UpdateProviderResponses[0], nil
+}
+
+// DeleteProvider implements the DeleteProvider transaction
+func (m *MockProviderMsgServer) DeleteProvider(ctx context.Context, req *providerv1beta4.MsgDeleteProvider) (*providerv1beta4.MsgDeleteProviderResponse, error) {
+	if len(m.DeleteProviderResponses) == 0 {
+		return &providerv1beta4.MsgDeleteProviderResponse{}, nil
+	}
+	return &m.DeleteProviderResponses[0], nil
+}

--- a/mock/node/mocks/staking_tx.go
+++ b/mock/node/mocks/staking_tx.go
@@ -1,0 +1,33 @@
+package mocks
+
+import (
+	"context"
+
+	stakingv1beta3 "pkg.akt.dev/go/node/staking/v1beta3"
+)
+
+// MockStakingMsgServer implements the staking message server for transactions
+type MockStakingMsgServer struct {
+	stakingv1beta3.UnimplementedMsgServer
+	UpdateParamsResponses []stakingv1beta3.MsgUpdateParamsResponse
+}
+
+// StakingTxData holds mock data for staking transactions
+type StakingTxData struct {
+	UpdateParamsResponses []stakingv1beta3.MsgUpdateParamsResponse `json:"update_params_responses"`
+}
+
+// NewMockStakingMsgServer creates a new mock staking message server
+func NewMockStakingMsgServer(data StakingTxData) *MockStakingMsgServer {
+	return &MockStakingMsgServer{
+		UpdateParamsResponses: data.UpdateParamsResponses,
+	}
+}
+
+// UpdateParams implements the UpdateParams transaction
+func (m *MockStakingMsgServer) UpdateParams(ctx context.Context, req *stakingv1beta3.MsgUpdateParams) (*stakingv1beta3.MsgUpdateParamsResponse, error) {
+	if len(m.UpdateParamsResponses) == 0 {
+		return &stakingv1beta3.MsgUpdateParamsResponse{}, nil
+	}
+	return &m.UpdateParamsResponses[0], nil
+}

--- a/mock/node/mocks/take_tx.go
+++ b/mock/node/mocks/take_tx.go
@@ -1,0 +1,33 @@
+package mocks
+
+import (
+	"context"
+
+	takev1 "pkg.akt.dev/go/node/take/v1"
+)
+
+// MockTakeMsgServer implements the take message server for transactions
+type MockTakeMsgServer struct {
+	takev1.UnimplementedMsgServer
+	UpdateParamsResponses []takev1.MsgUpdateParamsResponse
+}
+
+// TakeTxData holds mock data for take transactions
+type TakeTxData struct {
+	UpdateParamsResponses []takev1.MsgUpdateParamsResponse `json:"update_params_responses"`
+}
+
+// NewMockTakeMsgServer creates a new mock take message server
+func NewMockTakeMsgServer(data TakeTxData) *MockTakeMsgServer {
+	return &MockTakeMsgServer{
+		UpdateParamsResponses: data.UpdateParamsResponses,
+	}
+}
+
+// UpdateParams implements the UpdateParams transaction
+func (m *MockTakeMsgServer) UpdateParams(ctx context.Context, req *takev1.MsgUpdateParams) (*takev1.MsgUpdateParamsResponse, error) {
+	if len(m.UpdateParamsResponses) == 0 {
+		return &takev1.MsgUpdateParamsResponse{}, nil
+	}
+	return &m.UpdateParamsResponses[0], nil
+}


### PR DESCRIPTION
## 🌟 PR Title
feat: add base mock for transactions

## 📝 Description
Implements mock transaction methods to the node mock server. Takes the payload into the types and returns a generic empty transaction response. To be used to validate types can communicate with implemented backends.

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [X] Other: [Test framework]

## ✅ Checklist
- [X] I've updated relevant documentation
- [X] Code follows Akash Network's style guide
- [X] I've added/updated relevant unit tests
- [X] Dependencies have been properly updated
- [X] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)
