### PR TITLE
fix(ts): ensure that we create only 1 stargate client per sdk

### DIFF
--- a/ts/src/sdk/transport/tx/createStargateClient/createStargateClient.ts
+++ b/ts/src/sdk/transport/tx/createStargateClient/createStargateClient.ts
@@ -25,8 +25,8 @@ export function createStargateClient(options: StargateClientOptions): TxClient {
   const registry = new Registry([...defaultRegistryTypes, ...builtInTypes]);
   const createStargateClient = options.createClient ?? SigningStargateClient.connectWithSigner;
 
-  let stargateClient: SigningStargateClient | undefined;
-  const getStargateClient = async () => stargateClient ??= await createStargateClient(
+  let stargateClientPromise: Promise<SigningStargateClient> | undefined;
+  const getStargateClient = () => stargateClientPromise ??= createStargateClient(
     options.baseUrl,
     options.signer,
     {


### PR DESCRIPTION
## 🌟 PR Title
ensure that we create only 1 stargate client per sdk

## 📝 Description


## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
