### PR TITLE
fix(ts): removes defaultRegistryTypes from cosmjs

### DIFF
--- a/ts/src/sdk/transport/tx/createStargateClient/createStargateClient.ts
+++ b/ts/src/sdk/transport/tx/createStargateClient/createStargateClient.ts
@@ -11,7 +11,6 @@ import type {
   SigningStargateClientOptions,
 } from "@cosmjs/stargate";
 import {
-  defaultRegistryTypes,
   SigningStargateClient,
 } from "@cosmjs/stargate";
 
@@ -22,7 +21,7 @@ const DEFAULT_GAS_MULTIPLIER = 1.3;
 
 export function createStargateClient(options: StargateClientOptions): TxClient {
   const builtInTypes = options.builtInTypes?.map((type) => [type.typeUrl, type] as [string, GeneratedType]) || [];
-  const registry = new Registry([...defaultRegistryTypes, ...builtInTypes]);
+  const registry = new Registry(builtInTypes);
   const createStargateClient = options.createClient ?? SigningStargateClient.connectWithSigner;
 
   let stargateClientPromise: Promise<SigningStargateClient> | undefined;


### PR DESCRIPTION
## 🌟 PR Title
removes defaultRegistryTypes from cosmjs

## 📝 Description

The issue is that `defaultRegistryTypes` from `"@cosmjs/stargate"` cannot translate js `Date` into google proto `Timestamp`. So, we can't rely on them because technically they are incompatible with ts-proto generated types

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
