### PR TITLE
fix(go/cli): set default value for minimum-gas-prices

### DIFF
--- a/go/cli/server.go
+++ b/go/cli/server.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	pruningtypes "cosmossdk.io/store/pruning/types"
 	cmtserver "github.com/cometbft/cometbft/abci/server"
 	cmtcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	cmtcfg "github.com/cometbft/cometbft/config"
@@ -26,6 +25,8 @@ import (
 	"github.com/cometbft/cometbft/proxy"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cometbft/cometbft/rpc/client/local"
+
+	pruningtypes "cosmossdk.io/store/pruning/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"


### PR DESCRIPTION
print warning if minumum-gas-prices is empty and set default value to 0.0025uakt. this prevents nodes failing to start with configurations carried from sdk 0.45

## 📝 Description
[Explain what this PR does in 2-3 sentences. Include context about the feature or problem being solved]

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [ ] Code follows Akash Network's style guide
- [ ] I've added/updated relevant unit tests
- [ ] Dependencies have been properly updated
- [ ] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
