### PR TITLE
feat(ts): exposes grpc transport options via SDK options for provider and chain

### DIFF
--- a/ts/src/sdk/chain/createChainNodeSDK.ts
+++ b/ts/src/sdk/chain/createChainNodeSDK.ts
@@ -8,6 +8,7 @@ import { TxRaw } from "../../generated/protos/cosmos/tx/v1beta1/tx.ts";
 import { createMessageType } from "../client/createServiceLoader.ts";
 import type { MessageDesc } from "../client/types.ts";
 import { createNoopTransport } from "../transport/createNoopTransport.ts";
+import type { GrpcTransportOptions } from "../transport/grpc/createGrpcTransport.ts";
 import { createGrpcTransport } from "../transport/grpc/createGrpcTransport.ts";
 import type { StargateClientOptions } from "../transport/tx/createStargateClient/createStargateClient.ts";
 import { createStargateClient } from "../transport/tx/createStargateClient/createStargateClient.ts";
@@ -18,6 +19,7 @@ export type { PayloadOf, ResponseOf } from "../types.ts";
 
 export function createChainNodeSDK(options: ChainNodeSDKOptions) {
   const queryTransport = createGrpcTransport({
+    ...options.query.transportOptions,
     baseUrl: options.query.baseUrl,
   });
   let txTransport: Transport<TxCallOptions>;
@@ -59,6 +61,12 @@ export interface ChainNodeSDKOptions {
      * Blockchain gRPC endpoint
      */
     baseUrl: string;
+
+    /**
+     * Options for the gRPC transport
+     */
+    transportOptions?: Pick<GrpcTransportOptions, "pingIdleConnection" | "pingIntervalMs" | "pingTimeoutMs" | "idleConnectionTimeoutMs" | "defaultTimeoutMs">;
+
   };
   tx?: Omit<StargateClientOptions, "getMessageType" | "builtInTypes"> & {
     /**

--- a/ts/src/sdk/provider/createProviderSDK.spec.ts
+++ b/ts/src/sdk/provider/createProviderSDK.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { createProviderSDK } from "./createProviderSDK.ts";
+
+describe(createProviderSDK.name, () => {
+  it("creates ProviderSDK", () => {
+    const sdk = createProviderSDK({
+      baseUrl: "http://localhost:1317",
+      transportOptions: {
+        pingIdleConnection: true,
+        pingIntervalMs: 1000,
+        pingTimeoutMs: 1000,
+        idleConnectionTimeoutMs: 1000,
+        defaultTimeoutMs: 1000,
+      },
+    });
+
+    expect(sdk).toBeDefined();
+  });
+});

--- a/ts/src/sdk/provider/createProviderSDK.ts
+++ b/ts/src/sdk/provider/createProviderSDK.ts
@@ -1,5 +1,6 @@
 import { createSDK } from "../../generated/createProviderSDK.ts";
 import type { PickByPath } from "../../utils/types.ts";
+import type { GrpcTransportOptions } from "../transport/grpc/createGrpcTransport.ts";
 import { createGrpcTransport } from "../transport/grpc/createGrpcTransport.ts";
 
 export type { PayloadOf, ResponseOf } from "../types.ts";
@@ -16,6 +17,7 @@ export function createProviderSDK(options: ProviderSDKOptions): ProviderSDK {
 
   return createSDK(
     createGrpcTransport({
+      ...options.transportOptions,
       baseUrl: options.baseUrl,
       nodeOptions: {
         ...certificateOptions,
@@ -30,6 +32,7 @@ export interface ProviderSDKOptions {
    * Provider gRPC endpoint
    */
   baseUrl: string;
+
   /**
    * Authentication options
    */
@@ -38,4 +41,9 @@ export interface ProviderSDKOptions {
     cert: string;
     key: string;
   };
+
+  /**
+   * Options for the gRPC transport
+   */
+  transportOptions?: Pick<GrpcTransportOptions, "pingIdleConnection" | "pingIntervalMs" | "pingTimeoutMs" | "idleConnectionTimeoutMs" | "defaultTimeoutMs">;
 }


### PR DESCRIPTION
## 📝 Description

Exposes grpc transport options that allow to fine tune http layer per SDK

## 🔧 Purpose of the Change
- [x] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- References https://github.com/akash-network/console/pull/2082/files#r2454713462

## ✅ Checklist
- [ ] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
