### PR TITLE
fix(ts): skips type patching for gRPC gateway transport since it is done on gateway side

### DIFF
--- a/ts/src/sdk/client/createServiceClient.spec.ts
+++ b/ts/src/sdk/client/createServiceClient.spec.ts
@@ -589,6 +589,7 @@ describe(createServiceClient.name, () => {
     });
 
     return {
+      requiresTypePatching: true,
       unary: notImplemented,
       stream: notImplemented,
       [responseType]: method,

--- a/ts/src/sdk/client/createServiceClient.ts
+++ b/ts/src/sdk/client/createServiceClient.ts
@@ -24,7 +24,7 @@ export function createServiceClient<TSchema extends ServiceDesc, TCallOptions>(
   transport: Transport<TCallOptions>,
   options?: ServiceClientOptions,
 ): Client<TSchema, TCallOptions> {
-  const methodOptions: MethodOptions = options?.typePatches
+  const methodOptions: MethodOptions = transport.requiresTypePatching && options?.typePatches
     ? { encode: createEncodeWithPatches(options.typePatches), decode: createDecodeWithPatches(options.typePatches) }
     : defaultEncoder;
   const client: Record<string, ReturnType<typeof createMethod>> = {};

--- a/ts/src/sdk/transport/grpc/createGrpcTransport.ts
+++ b/ts/src/sdk/transport/grpc/createGrpcTransport.ts
@@ -45,6 +45,7 @@ export function createGrpcTransport(options: GrpcTransportOptions): Transport<Gr
   const httpClient = options.httpClient ?? createDefaultHttpClient(options);
 
   return {
+    requiresTypePatching: true,
     async unary<I extends MessageDesc, O extends MessageDesc>(
       method: MethodDesc<"unary", I, O>,
       message: MessageInitShape<I>,

--- a/ts/src/sdk/transport/tx/createTxTransport.ts
+++ b/ts/src/sdk/transport/tx/createTxTransport.ts
@@ -8,6 +8,7 @@ import { TxError } from "./TxError.ts";
 
 export function createTxTransport(transportOptions: TransactionTransportOptions): Transport<TxCallOptions> {
   return {
+    requiresTypePatching: true,
     async unary<I extends MessageDesc, O extends MessageDesc>(
       method: MethodDesc<"unary", I, O>,
       input: MessageInitShape<I>,

--- a/ts/src/sdk/transport/types.ts
+++ b/ts/src/sdk/transport/types.ts
@@ -15,6 +15,7 @@ export interface TxCallOptions {
 }
 
 export interface Transport<TCallOptions = unknown> {
+  requiresTypePatching?: boolean;
   /**
    * Call a unary RPC - a method that takes a single input message, and
    * responds with a single output message.


### PR DESCRIPTION
## 📝 Description

skips type patching for gRPC gateway transport since it is done on gateway side

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] ~I've updated relevant documentation~
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
