### PR TITLE
fix(ts): decodes/encodes negative LegacyDec values

### DIFF
--- a/ts/src/encoding/customTypes/LegacyDec.spec.ts
+++ b/ts/src/encoding/customTypes/LegacyDec.spec.ts
@@ -4,7 +4,6 @@ import { LegacyDec } from "./LegacyDec.ts";
 
 describe(`Custom type: ${LegacyDec.typeName}`, () => {
   // @see https://github.com/cosmos/cosmos-sdk/blob/main/math/testdata/decimals.json
-  // import('@cosmjs/math').Decimal supports only non-negative decimals
   it.each([
     ["", ""],
     ["0", "0"],
@@ -13,7 +12,7 @@ describe(`Custom type: ${LegacyDec.typeName}`, () => {
     ["123", "123"],
     ["1234", "1'234"],
     ["01234", "1234"],
-    [".1234", "0.1234"],
+    ["0.1234", "0.1234"],
     ["0.1", "0.1"],
     ["0.01", "0.01"],
     ["0.001", "0.001"],
@@ -50,6 +49,10 @@ describe(`Custom type: ${LegacyDec.typeName}`, () => {
     ["0.000000000000000100", "0.0000000000000001"],
     ["0.000000000000000010", "0.00000000000000001"],
     ["0.000000000000000001", "0.000000000000000001"],
+    ["-10.0", "-10"],
+    ["-10000", "-10'000"],
+    ["-9999", "-9'999"],
+    ["-999999999999", "-999'999'999'999"],
     [Number.MAX_SAFE_INTEGER.toString(), Number.MAX_SAFE_INTEGER.toString()],
   ])("should properly decode %s", (amount, expected) => {
     const encodedAmount = LegacyDec.encode(amount);

--- a/ts/src/encoding/customTypes/LegacyDec.ts
+++ b/ts/src/encoding/customTypes/LegacyDec.ts
@@ -10,6 +10,21 @@ const PRECISION = 18;
 export const LegacyDec = {
   typeName: "cosmossdk.io/math.LegacyDec",
   shortName: "LegacyDec",
-  encode: (value: string) => value.length ? Decimal.fromUserInput(value, PRECISION).atomics : "",
-  decode: (value: string) => value.length ? Decimal.fromAtomics(value, PRECISION).toString() : "",
+  encode(value: string) {
+    if (!value.length) return "";
+    const { sign, value: positiveValue } = unsignedDecimal(value);
+    return sign + Decimal.fromUserInput(positiveValue, PRECISION).atomics;
+  },
+  decode(value: string) {
+    if (!value.length) return "";
+    const { sign, value: positiveValue } = unsignedDecimal(value);
+    return sign + Decimal.fromAtomics(positiveValue, PRECISION).toString();
+  },
 } as const satisfies CustomType<string, string>;
+
+// cosmjs Decimal supports only non-negative decimals: https://github.com/cosmos/cosmjs/issues/1897
+function unsignedDecimal(value: string) {
+  if (value[0] !== "-") return { sign: "", value };
+  const positiveValue = value.slice(1);
+  return { sign: "-", value: positiveValue };
+}


### PR DESCRIPTION
## 📝 Description

`@cosmjs/math` Decimal doesn't support negative values, that's why we need to add special handling to properly decode and encode negative Decimals. Deployment may have negative balance in case of overdraft.

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- References https://github.com/cosmos/cosmjs/issues/1897

## ✅ Checklist
- [ ] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
