### PR TITLE
fix(ts): ensures esbuild replaces imports with require calls

### DIFF
--- a/ts/esbuild.config.mjs
+++ b/ts/esbuild.config.mjs
@@ -30,7 +30,12 @@ const baseConfig = (config) => ({
 
 await Promise.all([
   esbuild.build(baseConfig({ format: 'esm' })),
-  esbuild.build(baseConfig({ format: 'cjs' })),
+  esbuild.build(baseConfig({
+    format: 'cjs',
+    supported: {
+      'dynamic-import': false
+    }
+  })),
 ]);
 console.log('Building JS SDK finished');
 


### PR DESCRIPTION
## 📝 Description

Affects only commonjs version of chain-sdk:

Dynamic `import` when imports cjs file, wraps all of its exports into `.default`, this makes it incompatible with ts type checking and runtime. Basically

```ts
// module.cjs
modulex.exports = { test: 1 }
```

when imported with `import`:

```ts
const module = await import('./module.cjs');
// module = { default: { test: 1 } }
```

So, to fix it I decided that it's easier to transform dynamic imports into dynamic require calls

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
User from discord found this bug

## ✅ Checklist
- [ ] ~I've updated relevant documentation~
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
