### PR TITLE
feat(ts): adds retry options to grpc transports

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -8,10 +8,10 @@ This package provides TypeScript bindings for the Akash API, generated from prot
 
 ## Installation
 
-⚠️ **NOTICE:** 
+⚠️ **NOTICE:**
 
 The new Chain SDK for TypeScript is currently in alpha. As such, small breaking changes may occur between versions.
-To ensure stability of your own scripts, pin a specific version of the SDK in your package.json (avoid using `^` or `~` in front of version). 
+To ensure stability of your own scripts, pin a specific version of the SDK in your package.json (avoid using `^` or `~` in front of version).
 
 We are actively gathering developer feedback and improving the DX (Developer Experience).
 Please report any issues or suggestions via:
@@ -211,6 +211,34 @@ const leaseDetails = await fetch(`https://some-provider.url:8443/lease/${lease.d
 - Do not create a new certificate for every request
 - Verify the provider's identity when it responds with a self-signed certificate
 
+### Transport Retry logic
+
+The SDK supports **automatic retries** with exponential backoff for **query** requests in all SDKs. By default, retry is disabled. To enable it, pass `transportOptions.retry`. Afterwards, it will retry on the next gRPC failure codes:
+
+- 14 - `TransportError.Code.Unavailable`
+- 4  - `TransportError.Code.DeadlineExceeded`,
+- 13 - `TransportError.Code.Internal`,
+- 2  - `TransportError.Code.Unknown`,
+
+**Example:**
+
+```ts
+import { createChainNodeSDK } from "@akashnetwork/chain-sdk";
+
+const sdk = createChainNodeSDK({
+  query: {
+    baseUrl: "http://grpc.sandbox-2.aksh.pw:9090",
+    transportOptions: {
+      retry: {
+        maxAttempts: 3,
+        maxDelayMs: 5_000,
+      },
+    },
+  },
+});
+```
+
+Exactly the same `transportOptions` options can be passed to chain web sdk and to provider sdk, to enable retries.
 
 ### Stack Definition Language (SDL)
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -17,6 +17,7 @@
         "@cosmjs/proto-signing": "~0.36.1",
         "@cosmjs/stargate": "~0.36.1",
         "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
         "js-yaml": "^4.1.0",
         "json-stable-stringify": "^1.3.0",
         "jsrsasign": "^11.1.0",
@@ -3405,6 +3406,15 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/collect-v8-coverage": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -61,6 +61,7 @@
     "@cosmjs/proto-signing": "~0.36.1",
     "@cosmjs/stargate": "~0.36.1",
     "base64-js": "^1.5.1",
+    "cockatiel": "^3.2.1",
     "js-yaml": "^4.1.0",
     "json-stable-stringify": "^1.3.0",
     "jsrsasign": "^11.1.0",

--- a/ts/src/sdk/chain/createChainNodeSDK.ts
+++ b/ts/src/sdk/chain/createChainNodeSDK.ts
@@ -6,6 +6,8 @@ import { getMessageType } from "../getMessageType.ts";
 import { createNoopTransport } from "../transport/createNoopTransport.ts";
 import type { GrpcTransportOptions } from "../transport/grpc/createGrpcTransport.ts";
 import { createGrpcTransport } from "../transport/grpc/createGrpcTransport.ts";
+import type { RetryOptions } from "../transport/interceptors/retry.ts";
+import { createRetryInterceptor, isRetryEnabled } from "../transport/interceptors/retry.ts";
 import { createTxTransport } from "../transport/tx/createTxTransport.ts";
 import type { TxClient } from "../transport/tx/TxClient.ts";
 import type { Transport, TxCallOptions } from "../transport/types.ts";
@@ -13,9 +15,11 @@ import type { Transport, TxCallOptions } from "../transport/types.ts";
 export type { PayloadOf, ResponseOf } from "../types.ts";
 
 export function createChainNodeSDK(options: ChainNodeSDKOptions) {
+  const { retry: retryOptions, ...transportOptions } = options.query.transportOptions ?? {};
   const queryTransport = createGrpcTransport({
-    ...options.query.transportOptions,
+    ...transportOptions,
     baseUrl: options.query.baseUrl,
+    interceptors: isRetryEnabled(retryOptions) ? [createRetryInterceptor(retryOptions)] : [],
   });
   let txTransport: Transport<TxCallOptions>;
 
@@ -48,8 +52,14 @@ export interface ChainNodeSDKOptions {
     /**
      * Options for the gRPC transport
      */
-    transportOptions?: Pick<GrpcTransportOptions, "pingIdleConnection" | "pingIntervalMs" | "pingTimeoutMs" | "idleConnectionTimeoutMs" | "defaultTimeoutMs">;
-
+    transportOptions?: {
+      pingIdleConnection?: GrpcTransportOptions["pingIdleConnection"];
+      pingIntervalMs?: GrpcTransportOptions["pingIntervalMs"];
+      pingTimeoutMs?: GrpcTransportOptions["pingTimeoutMs"];
+      idleConnectionTimeoutMs?: GrpcTransportOptions["idleConnectionTimeoutMs"];
+      defaultTimeoutMs?: GrpcTransportOptions["defaultTimeoutMs"];
+      retry?: RetryOptions;
+    };
   };
   tx?: {
     signer: TxClient;

--- a/ts/src/sdk/provider/createProviderSDK.ts
+++ b/ts/src/sdk/provider/createProviderSDK.ts
@@ -2,12 +2,15 @@ import { createSDK } from "../../generated/createProviderSDK.ts";
 import type { PickByPath } from "../../utils/types.ts";
 import type { GrpcTransportOptions } from "../transport/grpc/createGrpcTransport.ts";
 import { createGrpcTransport } from "../transport/grpc/createGrpcTransport.ts";
+import type { RetryOptions } from "../transport/interceptors/retry.ts";
+import { createRetryInterceptor, isRetryEnabled } from "../transport/interceptors/retry.ts";
 
 export type { PayloadOf, ResponseOf } from "../types.ts";
 
 type ProviderSDK = PickByPath<ReturnType<typeof createSDK>, "akash.provider.v1">;
 
 export function createProviderSDK(options: ProviderSDKOptions): ProviderSDK {
+  const { retry: retryOptions, ...transportOptions } = options.transportOptions ?? {};
   const certificateOptions = options.authentication?.type === "mtls"
     ? {
         cert: options.authentication?.cert,
@@ -17,7 +20,8 @@ export function createProviderSDK(options: ProviderSDKOptions): ProviderSDK {
 
   return createSDK(
     createGrpcTransport({
-      ...options.transportOptions,
+      ...transportOptions,
+      interceptors: isRetryEnabled(retryOptions) ? [createRetryInterceptor(retryOptions)] : [],
       baseUrl: options.baseUrl,
       nodeOptions: {
         ...certificateOptions,
@@ -45,5 +49,12 @@ export interface ProviderSDKOptions {
   /**
    * Options for the gRPC transport
    */
-  transportOptions?: Pick<GrpcTransportOptions, "pingIdleConnection" | "pingIntervalMs" | "pingTimeoutMs" | "idleConnectionTimeoutMs" | "defaultTimeoutMs">;
+  transportOptions?: {
+    pingIdleConnection?: GrpcTransportOptions["pingIdleConnection"];
+    pingIntervalMs?: GrpcTransportOptions["pingIntervalMs"];
+    pingTimeoutMs?: GrpcTransportOptions["pingTimeoutMs"];
+    idleConnectionTimeoutMs?: GrpcTransportOptions["idleConnectionTimeoutMs"];
+    defaultTimeoutMs?: GrpcTransportOptions["defaultTimeoutMs"];
+    retry?: RetryOptions;
+  };
 }

--- a/ts/src/sdk/transport/grpc-gateway/createGrpcGatewayTransport.ts
+++ b/ts/src/sdk/transport/grpc-gateway/createGrpcGatewayTransport.ts
@@ -2,6 +2,7 @@ import { createContextValues } from "@connectrpc/connect";
 import { requestHeaderWithCompression } from "@connectrpc/connect/protocol-grpc";
 import { type GrpcTransportOptions as ConnectGrpcTransportOptions } from "@connectrpc/connect-node";
 
+import { base64FromBytes } from "../../../encoding/typeEncodingHelpers.ts";
 import type { MessageDesc, MessageInitShape, MessageShape, MethodDesc } from "../../client/types.ts";
 import { runUnaryCall } from "../runCall.ts";
 import { TransportError } from "../TransportError.ts";
@@ -126,17 +127,4 @@ function serializeParams(message: Record<string, unknown>, params: URLSearchPara
     params.append(name, String(value));
   });
   return params;
-}
-
-function base64FromBytes(arr: Uint8Array): string {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((globalThis as any).Buffer) {
-    return globalThis.Buffer.from(arr).toString("base64");
-  } else {
-    let binary = "";
-    arr.forEach((byte) => {
-      binary += String.fromCharCode(byte);
-    });
-    return globalThis.btoa(binary);
-  }
 }

--- a/ts/src/sdk/transport/grpc/createGrpcTransport.spec.ts
+++ b/ts/src/sdk/transport/grpc/createGrpcTransport.spec.ts
@@ -1,0 +1,494 @@
+import type { DescMethodStreaming, DescMethodUnary } from "@bufbuild/protobuf";
+import type { UniversalClientFn } from "@connectrpc/connect/protocol";
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { proto } from "../../../../test/helpers/proto.ts";
+import { createAsyncIterable } from "../../client/stream.ts";
+import type { RetryOptions } from "../interceptors/retry.ts";
+import { createRetryInterceptor, isRetryEnabled } from "../interceptors/retry.ts";
+import { TransportError } from "../TransportError.ts";
+import { createGrpcTransport, type GrpcTransportOptions } from "./createGrpcTransport.ts";
+
+describe(createGrpcTransport.name, () => {
+  it("has `requiresTypePatching` set to true", async () => {
+    const transport = createGrpcTransport({ baseUrl: "https://api.example.com" });
+    expect(transport.requiresTypePatching).toBe(true);
+  });
+
+  describe("unary method", () => {
+    it("makes POST request to correct URL", async () => {
+      const { transport, httpClient, TestMethodSchema } = await setup();
+      const message = { userId: "123", status: "active" };
+
+      await transport.unary(TestMethodSchema, message);
+
+      expect(httpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://api.example.com/akash.test.unit.TestService/TestMethod",
+          method: "POST",
+        }),
+      );
+    });
+
+    it("serializes message in request body", async () => {
+      const { transport, httpClient, TestMethodSchema } = await setup();
+      const message = { userId: "123", status: "active" };
+
+      await transport.unary(TestMethodSchema, message);
+
+      expect(httpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            [Symbol.asyncIterator]: expect.any(Function),
+          }),
+        }),
+      );
+    });
+
+    it("sets default grpc headers and custom headers from call options", async () => {
+      const { transport, httpClient, TestMethodSchema } = await setup();
+      const message = { test: "data" };
+      const callOptions = {
+        header: { "X-Custom-Header": "custom-value" },
+      };
+
+      await transport.unary(TestMethodSchema, message, callOptions);
+
+      const [options] = httpClient.mock.calls[0];
+      const headers = options?.header as Headers;
+      expect(headers.get("Content-Type")).toBe("application/grpc+proto");
+      expect(headers.get("X-Custom-Header")).toBe("custom-value");
+    });
+
+    it("handles timeout from call options", async () => {
+      const { transport, httpClient, TestMethodSchema } = await setup();
+      const message = { test: "data" };
+
+      await transport.unary(TestMethodSchema, message, { timeoutMs: 2000 });
+
+      const [options] = httpClient.mock.calls[0];
+      const headers = options?.header as Headers;
+      expect(headers.get("Grpc-Timeout")).toBe("2000m");
+    });
+
+    it("uses default timeout when no call timeout provided", async () => {
+      const { transport, httpClient, TestMethodSchema } = await setup({ defaultTimeoutMs: 5000 });
+      const message = { test: "data" };
+
+      await transport.unary(TestMethodSchema, message);
+
+      const [options] = httpClient.mock.calls[0];
+      const headers = options?.header as Headers;
+      expect(headers.get("Grpc-Timeout")).toBe("5000m");
+    });
+
+    it("handles abort signal from call options", async () => {
+      const { transport, httpClient, TestMethodSchema } = await setup();
+      const message = { test: "data" };
+      const controller = new AbortController();
+
+      await transport.unary(TestMethodSchema, message, { signal: controller.signal });
+
+      expect(httpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it("returns correctly formatted unary response", async () => {
+      const { transport, TestMethodSchema } = await setup();
+      const message = { test: "data" };
+
+      const result = await transport.unary(TestMethodSchema, message);
+
+      expect(result.header).toBeInstanceOf(Headers);
+      expect(result.trailer).toBeInstanceOf(Headers);
+      expect(result.message).toBeDefined();
+      expect(result.method).toBe(TestMethodSchema);
+      expect(result.stream).toBe(false);
+    });
+
+    it("throws error when response contains extra messages", async () => {
+      const { transport, TestMethodSchema } = await setup({ multipleMessages: true });
+      const message = { test: "data" };
+
+      await expect(transport.unary(TestMethodSchema, message)).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining("extra output message"),
+        }),
+      );
+    });
+
+    it("throws error when response contains no message", async () => {
+      const { transport, TestMethodSchema } = await setup({ emptyResponse: true });
+      const message = { test: "data" };
+
+      await expect(transport.unary(TestMethodSchema, message)).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining("missing output message"),
+        }),
+      );
+    });
+
+    describe("with retry interceptor", () => {
+      it("retries failed requests up to maxAttempts", async () => {
+        const { transport, httpClient, TestMethodSchema } = await setup({ retryOptions: { maxAttempts: 3, maxDelayMs: 10 } });
+        const message = { test: "data" };
+        const responseMessageBytes = TestMethodSchema.output.encode({ result: "success" }).finish();
+
+        httpClient
+          .mockRejectedValueOnce(new TransportError("Network error"))
+          .mockRejectedValueOnce(new TransportError("Network error"))
+          .mockRejectedValueOnce(new TransportError("Network error"))
+          .mockImplementationOnce(createMockHttpClient(responseMessageBytes));
+
+        const result = await transport.unary(TestMethodSchema, message);
+
+        expect(httpClient).toHaveBeenCalledTimes(4);
+        expect(result.message).toBeDefined();
+      });
+
+      it("throws after exhausting all retry attempts", async () => {
+        const { transport, httpClient, TestMethodSchema } = await setup({ retryOptions: { maxAttempts: 3, maxDelayMs: 10 } });
+        const message = { test: "data" };
+
+        httpClient
+          .mockRejectedValueOnce(new TransportError("Network error 1"))
+          .mockRejectedValueOnce(new TransportError("Network error 2"))
+          .mockRejectedValueOnce(new TransportError("Network error 3"))
+          .mockRejectedValueOnce(new TransportError("Network error 4"));
+
+        await expect(transport.unary(TestMethodSchema, message)).rejects.toThrow("Network error 4");
+        expect(httpClient).toHaveBeenCalledTimes(4);
+      });
+
+      it("succeeds on first attempt without retry", async () => {
+        const { transport, httpClient, TestMethodSchema } = await setup({ retryOptions: { maxAttempts: 3, maxDelayMs: 10 } });
+        const message = { test: "data" };
+
+        const result = await transport.unary(TestMethodSchema, message);
+
+        expect(httpClient).toHaveBeenCalledTimes(1);
+        expect(result.message).toBeDefined();
+      });
+
+      it("uses max 3 attempts when maxAttempts is bigger than 3", async () => {
+        const { transport, httpClient, TestMethodSchema } = await setup({ retryOptions: { maxAttempts: 5, maxDelayMs: 10 } });
+        const message = { test: "data" };
+        const responseMessageBytes = TestMethodSchema.output.encode({ result: "success" }).finish();
+
+        httpClient
+          .mockRejectedValueOnce(new TransportError("Network error", TransportError.Code.Unavailable))
+          .mockRejectedValueOnce(new TransportError("Network error", TransportError.Code.Internal))
+          .mockRejectedValueOnce(new TransportError("Network error", TransportError.Code.DeadlineExceeded))
+          .mockRejectedValueOnce(new TransportError("Network error 4", TransportError.Code.Unknown))
+          .mockImplementationOnce(createMockHttpClient(responseMessageBytes));
+
+        await expect(transport.unary(TestMethodSchema, message)).rejects.toThrow("Network error 4");
+        expect(httpClient).toHaveBeenCalledTimes(4);
+      });
+    });
+
+    async function setup(
+      input?: Partial<GrpcTransportOptions> & {
+        multipleMessages?: boolean;
+        emptyResponse?: boolean;
+        headerError?: boolean;
+        retryOptions?: RetryOptions;
+      },
+    ) {
+      const { TestMethodSchema } = await setupMethod();
+      const responseMessageBytes = TestMethodSchema.output.encode({ result: "success" }).finish();
+      const { multipleMessages, emptyResponse, headerError, retryOptions, ...transportOptions } = input ?? {};
+
+      const httpClient = jest.fn<UniversalClientFn>(createMockHttpClient(responseMessageBytes, {
+        multipleMessages, emptyResponse, headerError,
+      }));
+      const options: GrpcTransportOptions = {
+        baseUrl: "https://api.example.com",
+        httpClient,
+        defaultTimeoutMs: undefined,
+        ...transportOptions,
+      };
+
+      if (isRetryEnabled(retryOptions)) {
+        options.interceptors = [createRetryInterceptor(retryOptions)];
+      }
+      const transport = createGrpcTransport(options);
+
+      return { transport, httpClient, TestMethodSchema };
+    }
+
+    async function setupMethod() {
+      const def = await proto`
+        service TestService {
+          rpc TestMethod(TestInput) returns (TestOutput);
+        }
+
+        message TestInput {
+          string userId = 1;
+          string resourceId = 2;
+          string status = 3;
+          string name = 4;
+          int32 value = 5;
+          string test = 6;
+        }
+
+        message TestOutput {
+          string result = 1;
+          string id = 2;
+          bool created = 3;
+        }
+      `;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const TestInputSchema = def.getMessage<"TestInput", { userId: string; resourceId: string; status: string; name: string; value: number; test: string }>("TestInput");
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const TestOutputSchema = def.getMessage<"TestOutput", { result: string; id: string; created: boolean }>("TestOutput");
+      const TestServiceSchema = def.getTsProtoService<{
+        testMethod: DescMethodUnary<typeof TestInputSchema, typeof TestOutputSchema>;
+      }>("TestService");
+
+      const TestMethodSchema = {
+        ...TestServiceSchema.methods.testMethod,
+        kind: "unary" as const,
+      };
+
+      return { TestMethodSchema };
+    }
+  });
+
+  describe("stream method", () => {
+    it("makes POST request to correct URL", async () => {
+      const { transport, httpClient, TestStreamMethodSchema } = await setup();
+
+      await transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]));
+
+      expect(httpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://api.example.com/akash.test.unit.TestService/TestStreamMethod",
+          method: "POST",
+        }),
+      );
+    });
+
+    it("sets default grpc headers and custom headers from call options", async () => {
+      const { transport, httpClient, TestStreamMethodSchema } = await setup();
+      const callOptions = {
+        header: { "X-Custom-Header": "custom-value" },
+      };
+
+      await transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]), callOptions);
+
+      const [options] = httpClient.mock.calls[0];
+      const headers = options?.header as Headers;
+      expect(headers.get("X-Custom-Header")).toBe("custom-value");
+      expect(headers.get("Content-Type")).toBe("application/grpc+proto");
+    });
+
+    it("handles timeout from call options", async () => {
+      const { transport, httpClient, TestStreamMethodSchema } = await setup();
+      const callOptions = { timeoutMs: 2000 };
+
+      await transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]), callOptions);
+
+      const [options] = httpClient.mock.calls[0];
+      const headers = options?.header as Headers;
+      expect(headers.get("Grpc-Timeout")).toBe("2000m");
+    });
+
+    it("returns correctly formatted stream response", async () => {
+      const { transport, TestStreamMethodSchema } = await setup();
+
+      const result = await transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]));
+
+      expect(result.header).toBeInstanceOf(Headers);
+      expect(result.trailer).toBeInstanceOf(Headers);
+      expect(result.message).toBeDefined();
+      expect(result.method).toBe(TestStreamMethodSchema);
+      expect(result.stream).toBe(true);
+    });
+
+    it("yields multiple messages from stream", async () => {
+      const { transport, TestStreamMethodSchema } = await setup({ multipleMessages: true });
+
+      const result = await transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]));
+
+      const messages: unknown[] = [];
+      for await (const message of result.message) {
+        messages.push(message);
+      }
+
+      expect(messages.length).toBe(2);
+    });
+
+    it("throws error on header error", async () => {
+      const { transport, TestStreamMethodSchema } = await setup({ headerError: true });
+
+      await expect(transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]))).rejects.toThrow(TransportError);
+    });
+
+    describe("with retry interceptor", () => {
+      it("retries failed requests up to maxAttempts", async () => {
+        const { transport, httpClient, TestStreamMethodSchema } = await setup({ retryOptions: { maxAttempts: 3, maxDelayMs: 10 } });
+        const responseMessageBytes = TestStreamMethodSchema.output.encode({ result: "success" }).finish();
+
+        httpClient
+          .mockRejectedValueOnce(new TransportError("Network error"))
+          .mockRejectedValueOnce(new TransportError("Network error"))
+          .mockRejectedValueOnce(new TransportError("Network error"))
+          .mockImplementationOnce(createMockHttpClient(responseMessageBytes));
+
+        const result = await transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]));
+
+        expect(httpClient).toHaveBeenCalledTimes(4);
+        expect(result.message).toBeDefined();
+      });
+
+      it("throws after exhausting all retry attempts", async () => {
+        const { transport, httpClient, TestStreamMethodSchema } = await setup({ retryOptions: { maxAttempts: 3, maxDelayMs: 10 } });
+
+        httpClient
+          .mockRejectedValueOnce(new TransportError("Network error 1"))
+          .mockRejectedValueOnce(new TransportError("Network error 2"))
+          .mockRejectedValueOnce(new TransportError("Network error 3"))
+          .mockRejectedValueOnce(new TransportError("Network error 4"));
+
+        await expect(transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]))).rejects.toThrow("Network error 4");
+        expect(httpClient).toHaveBeenCalledTimes(4);
+      });
+
+      it("succeeds on first attempt without retry", async () => {
+        const { transport, httpClient, TestStreamMethodSchema } = await setup({ retryOptions: { maxAttempts: 3, maxDelayMs: 10 } });
+
+        const result = await transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]));
+
+        expect(httpClient).toHaveBeenCalledTimes(1);
+        expect(result.message).toBeDefined();
+      });
+
+      it("uses max 3 attempts when maxAttempts is bigger than 3", async () => {
+        const { transport, httpClient, TestStreamMethodSchema } = await setup({ retryOptions: { maxAttempts: 5, maxDelayMs: 10 } });
+        const responseMessageBytes = TestStreamMethodSchema.output.encode({ result: "success" }).finish();
+
+        httpClient
+          .mockRejectedValueOnce(new TransportError("Network error", TransportError.Code.Unavailable))
+          .mockRejectedValueOnce(new TransportError("Network error", TransportError.Code.Internal))
+          .mockRejectedValueOnce(new TransportError("Network error", TransportError.Code.DeadlineExceeded))
+          .mockRejectedValueOnce(new TransportError("Network error 4", TransportError.Code.Unknown))
+          .mockImplementationOnce(createMockHttpClient(responseMessageBytes));
+
+        await expect(transport.stream(TestStreamMethodSchema, createAsyncIterable([{ test: "data" }]))).rejects.toThrow("Network error 4");
+        expect(httpClient).toHaveBeenCalledTimes(4);
+      });
+    });
+
+    async function setup(
+      input?: {
+        multipleMessages?: boolean;
+        headerError?: boolean;
+        retryOptions?: RetryOptions;
+      },
+    ) {
+      const { TestStreamMethodSchema } = await setupMethod();
+      const responseMessageBytes = TestStreamMethodSchema.output.encode({ result: "success" }).finish();
+      const { multipleMessages, headerError, retryOptions } = input ?? {};
+
+      const httpClient = jest.fn<UniversalClientFn>(createMockHttpClient(responseMessageBytes, { multipleMessages, headerError }));
+      const options: GrpcTransportOptions = {
+        baseUrl: "https://api.example.com",
+        httpClient,
+      };
+
+      if (isRetryEnabled(retryOptions)) {
+        options.interceptors = [createRetryInterceptor(retryOptions)];
+      }
+      const transport = createGrpcTransport(options);
+
+      return { transport, httpClient, TestStreamMethodSchema };
+    }
+
+    async function setupMethod() {
+      const def = await proto`
+        service TestService {
+          rpc TestStreamMethod(TestInput) returns (stream TestOutput);
+        }
+
+        message TestInput {
+          string test = 1;
+        }
+
+        message TestOutput {
+          string result = 1;
+        }
+      `;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const TestInputSchema = def.getMessage<"TestInput", { test: string }>("TestInput");
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const TestOutputSchema = def.getMessage<"TestOutput", { result: string }>("TestOutput");
+      const TestServiceSchema = def.getTsProtoService<{
+        testStreamMethod: DescMethodStreaming<typeof TestInputSchema, typeof TestOutputSchema>;
+      }>("TestService");
+
+      const TestStreamMethodSchema = {
+        ...TestServiceSchema.methods.testStreamMethod,
+        kind: "server_streaming" as const,
+      };
+
+      return { TestStreamMethodSchema };
+    }
+  });
+
+  function createMockHttpClient(
+    responseMessageBytes: Uint8Array,
+    options?: { multipleMessages?: boolean; emptyResponse?: boolean; headerError?: boolean },
+  ): UniversalClientFn {
+    return async () => {
+      const responseHeader = new Headers({
+        "content-type": "application/grpc+proto",
+        "grpc-status": options?.headerError ? "14" : "0",
+      });
+      const trailer = new Headers({
+        "grpc-status": "0",
+      });
+
+      if (options?.headerError) {
+        responseHeader.set("grpc-message", "Service unavailable");
+      }
+
+      let messages: Uint8Array[];
+      if (options?.emptyResponse) {
+        messages = [];
+      } else if (options?.multipleMessages) {
+        // Two messages in the response
+        messages = [
+          createGrpcFrame(responseMessageBytes),
+          createGrpcFrame(responseMessageBytes),
+        ];
+      } else {
+        // Single message response
+        messages = [createGrpcFrame(responseMessageBytes)];
+      }
+
+      return {
+        status: 200,
+        header: responseHeader,
+        trailer,
+        body: createAsyncIterable(messages),
+      };
+    };
+  }
+
+  function createGrpcFrame(data: Uint8Array): Uint8Array {
+    // gRPC frame: 1 byte compression flag + 4 bytes length + data
+    const frame = new Uint8Array(5 + data.length);
+    frame[0] = 0; // No compression
+    const length = data.length;
+    frame[1] = (length >> 24) & 0xff;
+    frame[2] = (length >> 16) & 0xff;
+    frame[3] = (length >> 8) & 0xff;
+    frame[4] = length & 0xff;
+    frame.set(data, 5);
+    return frame;
+  }
+});

--- a/ts/src/sdk/transport/interceptors/retry.ts
+++ b/ts/src/sdk/transport/interceptors/retry.ts
@@ -1,0 +1,43 @@
+import type { Interceptor } from "@connectrpc/connect";
+import {
+  ExponentialBackoff,
+  handleWhen,
+  retry,
+} from "cockatiel";
+
+import { TransportError } from "../TransportError.ts";
+
+const RETRIABLE_ERROR_CODES = new Set([
+  TransportError.Code.Unavailable,
+  TransportError.Code.DeadlineExceeded,
+  TransportError.Code.Internal,
+  TransportError.Code.Unknown,
+]);
+export function createRetryInterceptor(options: RetryOptions): Interceptor {
+  const retryPolicy = retry(handleWhen((error) => error instanceof TransportError && RETRIABLE_ERROR_CODES.has(error.code)), {
+    maxAttempts: Math.min(3, options.maxAttempts),
+    backoff: new ExponentialBackoff({
+      initialDelay: 250,
+      maxDelay: options.maxDelayMs ?? 5_000,
+    }),
+  });
+
+  return (next) => async (req) => retryPolicy.execute(() => next(req));
+}
+
+export function isRetryEnabled(options: RetryOptions | undefined): options is RetryOptions {
+  return !!options?.maxAttempts && !Number.isNaN(options.maxAttempts) && options.maxAttempts > 0;
+}
+
+export interface RetryOptions {
+  /**
+   * Maximum number of attempts to make after first failure.
+   * Maximum allowed value is 3.
+   */
+  maxAttempts: number;
+  /**
+   * Maximum delay between attempts in milliseconds. Used to restrict exponential backoff calculated value.
+   * Default value is 5000ms.
+   */
+  maxDelayMs?: number;
+}


### PR DESCRIPTION
## 📝 Description
Adds retry options, so the users don't need to do it in userland. It's useful for everybody, including console projects

## 🔧 Purpose of the Change
- [x] New feature implementation
- [ ] Bug fix
- [x] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes https://github.com/akash-network/chain-sdk/issues/161

## ✅ Checklist
- [x] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

