### PR TITLE
refactor: replaces allOf+if with clean oneOf structures

### DIFF
--- a/specs/jwt-schema.json
+++ b/specs/jwt-schema.json
@@ -15,8 +15,7 @@
     ],
     "properties": {
         "iss": {
-            "type": "string",
-            "pattern": "^akash1[a-z0-9]{38}$",
+            "$ref": "#/definitions/akash-address",
             "description": "Akash address of the lease(s) owner, e.g., akash1abcd... (44 characters)"
         },
         "iat": {
@@ -47,6 +46,49 @@
             "description": "Version of the JWT specification (currently fixed at v1)."
         },
         "leases": {
+            "$ref": "#/definitions/leases"
+        }
+    },
+    "definitions": {
+        "akash-address": {
+            "type": "string",
+            "pattern": "^akash1[a-z0-9]{38}$"
+        },
+        "action-scope": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": [
+                    "send-manifest",
+                    "get-manifest",
+                    "logs",
+                    "shell",
+                    "events",
+                    "status",
+                    "restart",
+                    "hostname-migrate",
+                    "ip-migrate"
+                ]
+            }
+        },
+        "leases": {
+            "type": "object",
+            "description": "Access level for the lease: 'full' for unrestricted access to all actions, 'scoped' for specific actions across all provider leases, 'granular' for provider-specific permissions.",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/leases-full"
+                },
+                {
+                    "$ref": "#/definitions/leases-scoped"
+                },
+                {
+                    "$ref": "#/definitions/leases-granular"
+                }
+            ]
+        },
+        "leases-full": {
             "type": "object",
             "additionalProperties": false,
             "required": [
@@ -54,334 +96,177 @@
             ],
             "properties": {
                 "access": {
-                    "type": "string",
-                    "enum": [
-                        "full",
-                        "granular",
-                        "scoped"
-                    ],
-                    "description": "Access level for the lease: 'full' for unrestricted access to all actions, 'scoped' for specific actions across all provider leases,'granular' for provider-specific permissions."
+                    "const": "full",
+                    "description": "Unrestricted access to all actions on all leases."
+                }
+            }
+        },
+        "leases-scoped": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "access",
+                "scope"
+            ],
+            "properties": {
+                "access": {
+                    "const": "scoped",
+                    "description": "Specific actions across all provider leases."
                 },
                 "scope": {
+                    "$ref": "#/definitions/action-scope",
+                    "description": "Global list of permitted actions across all owned leases (no duplicates)."
+                }
+            }
+        },
+        "leases-granular": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "access",
+                "permissions"
+            ],
+            "properties": {
+                "access": {
+                    "const": "granular",
+                    "description": "Provider-specific permissions."
+                },
+                "permissions": {
+                    "type": "array",
+                    "description": "Defines provider-specific permissions. The provider address must be unique across all permissions entries.",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/lease-permission"
+                    }
+                }
+            }
+        },
+        "lease-permission": {
+            "type": "object",
+            "description": "Provider-level access: 'full' for all actions, 'scoped' for specific actions across all provider leases, 'granular' for deployment-specific actions.",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/lease-permission-full"
+                },
+                {
+                    "$ref": "#/definitions/lease-permission-scoped"
+                },
+                {
+                    "$ref": "#/definitions/lease-permission-granular"
+                }
+            ]
+        },
+        "lease-permission-full": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "provider",
+                "access"
+            ],
+            "properties": {
+                "provider": {
+                    "$ref": "#/definitions/akash-address",
+                    "description": "Provider address, e.g., akash1xyz... (44 characters)."
+                },
+                "access": {
+                    "const": "full",
+                    "description": "Full access to all actions on this provider's leases."
+                }
+            }
+        },
+        "lease-permission-scoped": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "provider",
+                "access",
+                "scope"
+            ],
+            "properties": {
+                "provider": {
+                    "$ref": "#/definitions/akash-address",
+                    "description": "Provider address, e.g., akash1xyz... (44 characters)."
+                },
+                "access": {
+                    "const": "scoped",
+                    "description": "Specific actions across all this provider's leases."
+                },
+                "scope": {
+                    "$ref": "#/definitions/action-scope",
+                    "description": "Provider-level list of permitted actions (no duplicates)."
+                }
+            }
+        },
+        "lease-permission-granular": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "provider",
+                "access",
+                "deployments"
+            ],
+            "properties": {
+                "provider": {
+                    "$ref": "#/definitions/akash-address",
+                    "description": "Provider address, e.g., akash1xyz... (44 characters)."
+                },
+                "access": {
+                    "const": "granular",
+                    "description": "Deployment-specific actions."
+                },
+                "deployments": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/lease-permission-deployment"
+                    }
+                }
+            }
+        },
+        "lease-permission-deployment": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "dseq",
+                "scope",
+                "services"
+            ],
+            "properties": {
+                "dseq": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Deployment sequence number."
+                },
+                "scope": {
+                    "$ref": "#/definitions/action-scope",
+                    "description": "Deployment-level list of permitted actions (no duplicates)."
+                },
+                "gseq": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Group sequence number (requires dseq)."
+                },
+                "oseq": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Order sequence number (requires dseq and gseq)."
+                },
+                "services": {
                     "type": "array",
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
                         "type": "string",
-                        "enum": [
-                            "send-manifest",
-                            "get-manifest",
-                            "logs",
-                            "shell",
-                            "events",
-                            "status",
-                            "restart",
-                            "hostname-migrate",
-                            "ip-migrate"
-                        ]
+                        "minLength": 1
                     },
-                    "description": "Global list of permitted actions across all owned leases (no duplicates). Required when access is 'scoped'."
-                },
-                "permissions": {
-                    "type": "array",
-                    "description": "Required if leases.access is 'granular'; defines provider-specific permissions. The provider address must be unique across all permissions entries.",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": [
-                            "provider",
-                            "access"
-                        ],
-                        "properties": {
-                            "provider": {
-                                "type": "string",
-                                "pattern": "^akash1[a-z0-9]{38}$",
-                                "description": "Provider address, e.g., akash1xyz... (44 characters)."
-                            },
-                            "access": {
-                                "type": "string",
-                                "enum": [
-                                    "full",
-                                    "scoped",
-                                    "granular"
-                                ],
-                                "description": "Provider-level access: 'full' for all actions, 'scoped' for specific actions across all provider leases, 'granular' for deployment-specific actions."
-                            },
-                            "scope": {
-                                "type": "array",
-                                "minItems": 1,
-                                "uniqueItems": true,
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "send-manifest",
-                                        "get-manifest",
-                                        "logs",
-                                        "shell",
-                                        "events",
-                                        "status",
-                                        "restart",
-                                        "hostname-migrate",
-                                        "ip-migrate"
-                                    ]
-                                },
-                                "description": "Provider-level list of permitted actions for 'scoped' access (no duplicates)."
-                            },
-                            "deployments": {
-                                "type": "array",
-                                "minItems": 1,
-                                "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "dseq",
-                                        "scope",
-                                        "services"
-                                    ],
-                                    "properties": {
-                                        "dseq": {
-                                            "type": "integer",
-                                            "minimum": 1,
-                                            "description": "Deployment sequence number."
-                                        },
-                                        "scope": {
-                                            "type": "array",
-                                            "minItems": 1,
-                                            "uniqueItems": true,
-                                            "items": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "send-manifest",
-                                                    "get-manifest",
-                                                    "logs",
-                                                    "shell",
-                                                    "events",
-                                                    "status",
-                                                    "restart",
-                                                    "hostname-migrate",
-                                                    "ip-migrate"
-                                                ]
-                                            },
-                                            "description": "Deployment-level list of permitted actions (no duplicates)."
-                                        },
-                                        "gseq": {
-                                            "type": "integer",
-                                            "minimum": 0,
-                                            "description": "Group sequence number (requires dseq)."
-                                        },
-                                        "oseq": {
-                                            "type": "integer",
-                                            "minimum": 0,
-                                            "description": "Order sequence number (requires dseq and gseq)."
-                                        },
-                                        "services": {
-                                            "type": "array",
-                                            "minItems": 1,
-                                            "uniqueItems": true,
-                                            "items": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "description": "List of service names (requires dseq)."
-                                        }
-                                    },
-                                    "dependencies": {
-                                        "gseq": [
-                                            "dseq"
-                                        ],
-                                        "oseq": [
-                                            "dseq",
-                                            "gseq"
-                                        ],
-                                        "services": [
-                                            "dseq"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "allOf": [
-                            {
-                                "if": {
-                                    "properties": {
-                                        "access": {
-                                            "const": "scoped"
-                                        }
-                                    }
-                                },
-                                "then": {
-                                    "required": [
-                                        "scope"
-                                    ],
-                                    "properties": {
-                                        "scope": {
-                                            "minItems": 1
-                                        },
-                                        "deployments": false
-                                    }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "access": {
-                                            "const": "granular"
-                                        }
-                                    }
-                                },
-                                "then": {
-                                    "required": [
-                                        "deployments"
-                                    ],
-                                    "properties": {
-                                        "scope": false
-                                    }
-                                }
-                            },
-                            {
-                                "if": {
-                                    "properties": {
-                                        "access": {
-                                            "const": "full"
-                                        }
-                                    }
-                                },
-                                "then": {
-                                    "properties": {
-                                        "scope": false,
-                                        "deployments": false
-                                    }
-                                }
-                            }
-                        ]
-                    }
+                    "description": "List of service names (requires dseq)."
                 }
             },
-            "allOf": [
-                {
-                    "if": {
-                        "properties": {
-                            "access": {
-                                "const": "full"
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "permissions": false,
-                            "scope": false
-                        }
-                    }
-                },
-                {
-                    "if": {
-                        "properties": {
-                            "access": {
-                                "const": "scoped"
-                            }
-                        }
-                    },
-                    "then": {
-                        "required": [
-                            "scope"
-                        ],
-                        "properties": {
-                            "scope": {
-                                "minItems": 1
-                            },
-                            "permissions": false
-                        }
-                    }
-                },
-                {
-                    "if": {
-                        "properties": {
-                            "access": {
-                                "const": "granular"
-                            }
-                        },
-                        "required": [
-                            "access"
-                        ]
-                    },
-                    "then": {
-                        "required": [
-                            "permissions"
-                        ],
-                        "properties": {
-                            "scope": false
-                        }
-                    }
-                }
-            ]
-        }
-    },
-    "allOf": [
-        {
-            "if": {
-                "properties": {
-                    "leases": {
-                        "properties": {
-                            "access": {
-                                "const": "granular"
-                            }
-                        },
-                        "required": [
-                            "access"
-                        ]
-                    }
-                },
-                "required": [
-                    "leases"
+            "dependencies": {
+                "oseq": [
+                    "gseq"
                 ]
-            },
-            "then": {
-                "properties": {
-                    "leases": {
-                        "required": [
-                            "permissions"
-                        ],
-                        "properties": {
-                            "scope": false
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "if": {
-                "properties": {
-                    "leases": {
-                        "properties": {
-                            "permissions": {
-                                "type": "array",
-                                "minItems": 1
-                            }
-                        },
-                        "required": [
-                            "permissions"
-                        ]
-                    }
-                },
-                "required": [
-                    "leases"
-                ]
-            },
-            "then": {
-                "properties": {
-                    "leases": {
-                        "properties": {
-                            "access": {
-                                "const": "granular"
-                            }
-                        },
-                        "required": [
-                            "access"
-                        ]
-                    }
-                }
             }
         }
-    ]
+    }
 }


### PR DESCRIPTION
## 📝 Description

Using `oneOf` instead of `allOf + if` makes it easier to see discriminated union in payload shape. Additionally, it improves tooling support, for example json-schema-to-typescript can generate correct types from oneOf schema and we don't need to write it manually.

In terms of validation, it supports the same rules as the previous one. However error messages will be different.

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [x] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] ~I've updated relevant documentation~
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
