### PR TITLE
fix(go/cli): respect path argument when stdin is a terminal

### DIFF
--- a/go/cli/gov_tx.go
+++ b/go/cli/gov_tx.go
@@ -1669,7 +1669,7 @@ func parseSubmitProposal(cdc codec.Codec, path string) (ProposalMsg, []sdk.Msg, 
 
 	var fl *os.File
 	var err error
-	if term.IsTerminal(0) || path == "-" {
+	if path == "-" || (path == "" && !term.IsTerminal(0)) {
 		fl = os.Stdin
 	} else {
 		fl, err = os.Open(path)


### PR DESCRIPTION
term.IsTerminal(0) returns true whenever stdin is connected to a terminal—which is almost always the case when a program is being run interactively from a shell. Since it's evaluated first and the operator is OR, the condition short-circuits and path were never checked.

## 📝 Description
[Explain what this PR does in 2-3 sentences. Include context about the feature or problem being solved]

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [ ] Code follows Akash Network's style guide
- [ ] I've added/updated relevant unit tests
- [ ] Dependencies have been properly updated
- [ ] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
