### PR TITLE
fix(cert): handle unencrypted and SEC 1 PEM private keys in readImpl

### DIFF
--- a/go/node/cert/v1/utils/key_pair_manager.go
+++ b/go/node/cert/v1/utils/key_pair_manager.go
@@ -281,8 +281,22 @@ func (kpm *keyPairManager) readImpl(fin io.Reader) ([]byte, []byte, []byte, erro
 			// nolint:staticcheck
 			privKeyPlaintext, err = x509.DecryptPEMBlock(block, kpm.passwordLegacy)
 		}
+	} else if block.Type == "PRIVATE KEY" {
+		// Unencrypted PKCS#8 private key (RFC 5958 / RFC 7468 section 10)
+		privKeyPlaintext = block.Bytes
+	} else if block.Type == "EC PRIVATE KEY" {
+		// SEC 1 / RFC 5915 EC private key — parse and re-marshal as PKCS#8
+		// so downstream code can uniformly call x509.ParsePKCS8PrivateKey.
+		ecKey, ecErr := x509.ParseECPrivateKey(block.Bytes)
+		if ecErr != nil {
+			return nil, nil, nil, fmt.Errorf("%w: failed parsing EC private key", ecErr)
+		}
+		privKeyPlaintext, err = x509.MarshalPKCS8PrivateKey(ecKey)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("%w: failed re-encoding EC key as PKCS#8", err)
+		}
 	} else {
-		return nil, nil, nil, errUnsupportedEncryptedPEM
+		return nil, nil, nil, fmt.Errorf("%w: PEM block type %q", errUnsupportedEncryptedPEM, block.Type)
 	}
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("%w: failed decrypting x509 block with private key", err)

--- a/go/node/cert/v1/utils/key_pair_manager_test.go
+++ b/go/node/cert/v1/utils/key_pair_manager_test.go
@@ -1,0 +1,120 @@
+package utils
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func generateTestCertAndKey(t *testing.T) (*ecdsa.PrivateKey, []byte) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "akash1testaddr"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365),
+		KeyUsage:     x509.KeyUsageDataEncipherment | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDer, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return priv, certDer
+}
+
+func TestReadImpl_UnencryptedPKCS8(t *testing.T) {
+	priv, certDer := generateTestCertAndKey(t)
+
+	keyDer, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: certDer})
+	_ = pem.Encode(&buf, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDer})
+
+	kpm := &keyPairManager{
+		addr: sdk.AccAddress("testaddr"),
+	}
+
+	cert, privKeyData, pubKey, err := kpm.readImpl(&buf)
+	if err != nil {
+		t.Fatalf("readImpl failed for unencrypted PKCS#8 key: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected non-nil cert")
+	}
+	if privKeyData == nil {
+		t.Fatal("expected non-nil private key data")
+	}
+	if pubKey == nil {
+		t.Fatal("expected non-nil public key")
+	}
+}
+
+func TestReadImpl_SEC1ECPrivateKey(t *testing.T) {
+	priv, certDer := generateTestCertAndKey(t)
+
+	ecDer, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: certDer})
+	_ = pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ecDer})
+
+	kpm := &keyPairManager{
+		addr: sdk.AccAddress("testaddr"),
+	}
+
+	cert, privKeyData, pubKey, err := kpm.readImpl(&buf)
+	if err != nil {
+		t.Fatalf("readImpl failed for SEC 1 EC private key: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected non-nil cert")
+	}
+	if privKeyData == nil {
+		t.Fatal("expected non-nil private key data")
+	}
+	if pubKey == nil {
+		t.Fatal("expected non-nil public key")
+	}
+}
+
+func TestReadImpl_UnknownPEMType(t *testing.T) {
+	_, certDer := generateTestCertAndKey(t)
+
+	var buf bytes.Buffer
+	_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: certDer})
+	_ = pem.Encode(&buf, &pem.Block{Type: "SOME UNKNOWN KEY", Bytes: []byte("garbage")})
+
+	kpm := &keyPairManager{
+		addr: sdk.AccAddress("testaddr"),
+	}
+
+	_, _, _, err := kpm.readImpl(&buf)
+	if err == nil {
+		t.Fatal("expected error for unknown PEM type, got nil")
+	}
+}

--- a/go/util/tls/key_pair_manager_test.go
+++ b/go/util/tls/key_pair_manager_test.go
@@ -1,0 +1,120 @@
+package tls
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func generateTestCertAndKey(t *testing.T) (*ecdsa.PrivateKey, []byte) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "akash1testaddr"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365),
+		KeyUsage:     x509.KeyUsageDataEncipherment | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDer, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return priv, certDer
+}
+
+func TestReadImpl_UnencryptedPKCS8(t *testing.T) {
+	priv, certDer := generateTestCertAndKey(t)
+
+	keyDer, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: certDer})
+	_ = pem.Encode(&buf, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDer})
+
+	kpm := &keyPairManager{
+		addr: sdk.AccAddress("testaddr"),
+	}
+
+	cert, privKeyData, pubKey, err := kpm.readImpl(&buf)
+	if err != nil {
+		t.Fatalf("readImpl failed for unencrypted PKCS#8 key: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected non-nil cert")
+	}
+	if privKeyData == nil {
+		t.Fatal("expected non-nil private key data")
+	}
+	if pubKey == nil {
+		t.Fatal("expected non-nil public key")
+	}
+}
+
+func TestReadImpl_SEC1ECPrivateKey(t *testing.T) {
+	priv, certDer := generateTestCertAndKey(t)
+
+	ecDer, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: certDer})
+	_ = pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ecDer})
+
+	kpm := &keyPairManager{
+		addr: sdk.AccAddress("testaddr"),
+	}
+
+	cert, privKeyData, pubKey, err := kpm.readImpl(&buf)
+	if err != nil {
+		t.Fatalf("readImpl failed for SEC 1 EC private key: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected non-nil cert")
+	}
+	if privKeyData == nil {
+		t.Fatal("expected non-nil private key data")
+	}
+	if pubKey == nil {
+		t.Fatal("expected non-nil public key")
+	}
+}
+
+func TestReadImpl_UnknownPEMType(t *testing.T) {
+	_, certDer := generateTestCertAndKey(t)
+
+	var buf bytes.Buffer
+	_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: certDer})
+	_ = pem.Encode(&buf, &pem.Block{Type: "SOME UNKNOWN KEY", Bytes: []byte("garbage")})
+
+	kpm := &keyPairManager{
+		addr: sdk.AccAddress("testaddr"),
+	}
+
+	_, _, _, err := kpm.readImpl(&buf)
+	if err == nil {
+		t.Fatal("expected error for unknown PEM type, got nil")
+	}
+}


### PR DESCRIPTION
## Description
`readImpl` in `key_pair_manager.go` only handled `ENCRYPTED PRIVATE KEY` and legacy `Proc-Type: 4,ENCRYPTED` PEM blocks. Unencrypted PKCS#8 (`PRIVATE KEY`) and SEC 1 (`EC PRIVATE KEY`) fell to the else branch, returning `errUnsupportedEncryptedPEM`. This breaks users whose mTLS cert PEM files have unencrypted private keys (e.g. generated externally or on macOS arm64 with Akash CLI v1.1.1).

## Purpose of the Change
- [x] Bug fix

## Related Issues
- Closes #236

## Checklist
- [ ] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [ ] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## Notes for Reviewers
The same bug exists in two copies of `readImpl`: `go/util/tls/key_pair_manager.go` and `go/node/cert/v1/utils/key_pair_manager.go`. Both are patched identically. A third copy in `akash-network/node` (`x/cert/utils/`) should be updated once this merges and the node bumps its `pkg.akt.dev/go` dependency. Unit tests are added for `go/util/tls/` covering unencrypted PKCS#8, SEC 1 EC, and unknown PEM type rejection.