### PR TITLE
fix: resource unit error with wrong interval

### DIFF
--- a/go/node/deployment/v1beta3/resourceunit.go
+++ b/go/node/deployment/v1beta3/resourceunit.go
@@ -94,7 +94,7 @@ func validateCPU(u *types.CPU) error {
 
 	if (u.Units.Value() > uint64(validationConfig.Unit.Max.CPU)) || (u.Units.Value() < uint64(validationConfig.Unit.Min.CPU)) {
 		return fmt.Errorf("error: invalid unit CPU (%v > %v > %v fails)",
-			validationConfig.Unit.Max.CPU, u.Units.Value(), validationConfig.Unit.Max.CPU)
+			validationConfig.Unit.Max.CPU, u.Units.Value(), validationConfig.Unit.Min.CPU)
 	}
 
 	if err := u.Attributes.Validate(); err != nil {
@@ -111,7 +111,7 @@ func validateGPU(u *types.GPU) error {
 
 	if (u.Units.Value() > uint64(validationConfig.Unit.Max.GPU)) || (u.Units.Value() < uint64(validationConfig.Unit.Min.GPU)) {
 		return fmt.Errorf("error: invalid unit GPU (%v > %v > %v fails)",
-			validationConfig.Unit.Max.GPU, u.Units.Value(), validationConfig.Unit.Max.GPU)
+			validationConfig.Unit.Max.GPU, u.Units.Value(), validationConfig.Unit.Min.GPU)
 	}
 
 	if u.Units.Value() == 0 && len(u.Attributes) > 0 {
@@ -131,7 +131,7 @@ func validateMemory(u *types.Memory) error {
 	}
 	if (u.Quantity.Value() > validationConfig.Unit.Max.Memory) || (u.Quantity.Value() < validationConfig.Unit.Min.Memory) {
 		return fmt.Errorf("error: invalid unit memory (%v > %v > %v fails)",
-			validationConfig.Unit.Max.Memory, u.Quantity.Value(), validationConfig.Unit.Max.Memory)
+			validationConfig.Unit.Max.Memory, u.Quantity.Value(), validationConfig.Unit.Min.Memory)
 	}
 
 	if err := u.Attributes.Validate(); err != nil {


### PR DESCRIPTION
## 📝 Description
This bug returns an inaccurate error message on resource unit intervals for invalid interval errors.

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## ✅ Checklist
- [x] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)