### PR TITLE
chore(ts): configures release-please to ignore BREAKING CHANGES

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,9 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "versioning": "prerelease",
-      "prerelease-type": "alpha"
+      "prerelease-type": "alpha",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## 📝 Description

release-please sets a new version of ts chain-sdk to 1.0.0  but it should be 1.0.0-alpha.30. So, reconfigured it to ignore BREAKING CHANGE commits (probably it was the reason)

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [x] Other: chore

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] ~I've updated relevant documentation~
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
