### PR TITLE
chore: upgrade release-please version to v5

### DIFF
--- a/.github/workflows/release-ts.yaml
+++ b/.github/workflows/release-ts.yaml
@@ -18,7 +18,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release-pl
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📝 Description

need a new version which supports Node 24 because Node20 is deprecated in gha

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [x] Other: chore

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
