### PR TITLE
chore(ts): change runner to ubuntu-latest for ts publish job

### DIFF
--- a/.github/workflows/release-ts.yaml
+++ b/.github/workflows/release-ts.yaml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     needs: release
     if: ${{ contains(fromJSON(needs.release.outputs.paths_released), 'ts') }}
     permissions:


### PR DESCRIPTION
## 📝 Description

OIDC token request is supported only by github hosted runners

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [x] Other: chore

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [ ] Code follows Akash Network's style guide
- [ ] I've added/updated relevant unit tests
- [ ] Dependencies have been properly updated
- [ ] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
