### PR TITLE
feat: add resource reclamation support to SDL and CLI (AEP-82)

### DIFF
--- a/go/cli/deployment_tx.go
+++ b/go/cli/deployment_tx.go
@@ -101,11 +101,17 @@ func GetTxDeploymentCreateCmd() *cobra.Command {
 				return err
 			}
 
+			reclamation, err := sdlManifest.Reclamation()
+			if err != nil {
+				return err
+			}
+
 			msg := &dv1beta.MsgCreateDeployment{
-				ID:      id,
-				Hash:    version,
-				Groups:  make(dv1beta.GroupSpecs, 0, len(groups)),
-				Deposit: dep,
+				ID:          id,
+				Hash:        version,
+				Groups:      make(dv1beta.GroupSpecs, 0, len(groups)),
+				Deposit:     dep,
+				Reclamation: reclamation,
 			}
 
 			msg.Groups = append(msg.Groups, groups...)

--- a/go/cli/flags/flags.go
+++ b/go/cli/flags/flags.go
@@ -87,6 +87,7 @@ const (
 	FlagOSeq                      = "oseq"
 	FlagProvider                  = "provider"
 	FlagClosedReason              = "reason"
+	FlagReclamationWindow         = "reclamation-window"
 	FlagSerial                    = "serial"
 	FlagPrice                     = "price"
 	FlagDeposit                   = "deposit"

--- a/go/cli/flags/market.go
+++ b/go/cli/flags/market.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -222,4 +223,29 @@ func BidClosedReasonFromFlags(flags *pflag.FlagSet) (mv1.LeaseClosedReason, erro
 	}
 
 	return reason, nil
+}
+
+// AddReclamationWindowFlag adds the optional reclamation window flag for bid creation.
+func AddReclamationWindowFlag(flags *pflag.FlagSet) {
+	flags.String(FlagReclamationWindow, "", "Reclamation window duration the provider offers (e.g. 24h, 720h). Optional.")
+}
+
+// ReclamationWindowFromFlags parses the --reclamation-window flag.
+// Returns nil if the flag is empty (not specified).
+func ReclamationWindowFromFlags(flags *pflag.FlagSet) (*time.Duration, error) {
+	val, err := flags.GetString(FlagReclamationWindow)
+	if err != nil {
+		return nil, err
+	}
+
+	if val == "" {
+		return nil, nil
+	}
+
+	d, err := time.ParseDuration(val)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --%s: %w", FlagReclamationWindow, err)
+	}
+
+	return &d, nil
 }

--- a/go/cli/market_tx.go
+++ b/go/cli/market_tx.go
@@ -36,6 +36,7 @@ func GetTxMarketBidCmds() *cobra.Command {
 	cmd.AddCommand(
 		GetTxMarketBidCreateCmd(),
 		GetTxMarketBidCloseCmd(),
+		GetTxMarketBidStartReclaimCmd(),
 	)
 	return cmd
 }
@@ -71,10 +72,16 @@ func GetTxMarketBidCreateCmd() *cobra.Command {
 				return err
 			}
 
+			reclaimWindow, err := cflags.ReclamationWindowFromFlags(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
 			msg := &mtypes.MsgCreateBid{
-				ID:      mv1.MakeBidID(id, cctx.GetFromAddress()),
-				Price:   coin,
-				Deposit: deposit,
+				ID:                mv1.MakeBidID(id, cctx.GetFromAddress()),
+				Price:             coin,
+				Deposit:           deposit,
+				ReclamationWindow: reclaimWindow,
 			}
 
 			if err := msg.ValidateBasic(); err != nil {
@@ -95,6 +102,7 @@ func GetTxMarketBidCreateCmd() *cobra.Command {
 
 	cmd.Flags().String("price", "", "Bid Price")
 	cflags.AddDepositFlags(cmd.Flags())
+	cflags.AddReclamationWindowFlag(cmd.Flags())
 
 	return cmd
 }
@@ -140,6 +148,49 @@ func GetTxMarketBidCloseCmd() *cobra.Command {
 
 	cflags.AddTxFlagsToCmd(cmd)
 	cflags.AddBidIDFlags(cmd.Flags())
+	cflags.AddBidClosedReasonFlag(cmd.Flags())
+
+	return cmd
+}
+
+func GetTxMarketBidStartReclaimCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "start-reclaim",
+		Short:             "Start reclamation on an active lease (provider only)",
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: TxPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustClientFromContext(ctx)
+			cctx := cl.ClientContext()
+
+			id, err := cflags.LeaseIDFromFlags(cmd.Flags(), cflags.WithProvider(cctx.FromAddress))
+			if err != nil {
+				return err
+			}
+
+			reason, err := cflags.BidClosedReasonFromFlags(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			msg := mtypes.NewMsgLeaseStartReclaim(id, reason)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			resp, err := cl.Tx().BroadcastMsgs(ctx, []sdk.Msg{msg})
+			if err != nil {
+				return err
+			}
+
+			return cl.PrintMessage(resp)
+		},
+	}
+
+	cflags.AddTxFlagsToCmd(cmd)
+	cflags.AddLeaseIDFlags(cmd.Flags())
 	cflags.AddBidClosedReasonFlag(cmd.Flags())
 
 	return cmd

--- a/go/sdl/_testdata/simple-reclamation-invalid.yaml
+++ b/go/sdl/_testdata/simple-reclamation-invalid.yaml
@@ -1,0 +1,43 @@
+---
+version: "2.0"
+reclamation:
+  min_window: "abc"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        accept:
+          - ahostname.com
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "100m"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "1Gi"
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        web:
+          denom: uact
+          amount: 50
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 2

--- a/go/sdl/_testdata/simple-reclamation-zero.yaml
+++ b/go/sdl/_testdata/simple-reclamation-zero.yaml
@@ -1,0 +1,43 @@
+---
+version: "2.0"
+reclamation:
+  min_window: "0s"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        accept:
+          - ahostname.com
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "100m"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "1Gi"
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        web:
+          denom: uact
+          amount: 50
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 2

--- a/go/sdl/_testdata/simple-reclamation.yaml
+++ b/go/sdl/_testdata/simple-reclamation.yaml
@@ -1,0 +1,47 @@
+---
+version: "2.0"
+reclamation:
+  min_window: "24h"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        accept:
+          - ahostname.com
+        to:
+          - global: true
+      - port: 12345
+        to:
+          - global: true
+        proto: udp
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "100m"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "1Gi"
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        web:
+          denom: uact
+          amount: 50
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 2

--- a/go/sdl/_testdata/v2.1-reclamation-invalid.yaml
+++ b/go/sdl/_testdata/v2.1-reclamation-invalid.yaml
@@ -1,0 +1,43 @@
+---
+version: "2.1"
+reclamation:
+  min_window: "abc"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        accept:
+          - ahostname.com
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "100m"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "1Gi"
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        web:
+          denom: uact
+          amount: 50
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 2

--- a/go/sdl/_testdata/v2.1-reclamation-zero.yaml
+++ b/go/sdl/_testdata/v2.1-reclamation-zero.yaml
@@ -1,0 +1,43 @@
+---
+version: "2.1"
+reclamation:
+  min_window: "0s"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        accept:
+          - ahostname.com
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "100m"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "1Gi"
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        web:
+          denom: uact
+          amount: 50
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 2

--- a/go/sdl/_testdata/v2.1-simple-reclamation.yaml
+++ b/go/sdl/_testdata/v2.1-simple-reclamation.yaml
@@ -1,0 +1,47 @@
+---
+version: "2.1"
+reclamation:
+  min_window: "24h"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        accept:
+          - ahostname.com
+        to:
+          - global: true
+      - port: 12345
+        to:
+          - global: true
+        proto: udp
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: "100m"
+        memory:
+          size: "128Mi"
+        storage:
+          size: "1Gi"
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - 1
+          - 2
+        allOf:
+          - 3
+          - 4
+      pricing:
+        web:
+          denom: uact
+          amount: 50
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 2

--- a/go/sdl/reclamation.go
+++ b/go/sdl/reclamation.go
@@ -1,0 +1,29 @@
+package sdl
+
+import (
+	"fmt"
+	"time"
+
+	dv1 "pkg.akt.dev/go/node/deployment/v1"
+)
+
+type v2Reclamation struct {
+	MinWindow string `yaml:"min_window"`
+}
+
+func (r *v2Reclamation) toDeploymentReclamation() (*dv1.DeploymentReclamation, error) {
+	if r == nil {
+		return nil, nil
+	}
+
+	d, err := time.ParseDuration(r.MinWindow)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid reclamation min_window %q: %v", errSDLInvalid, r.MinWindow, err)
+	}
+
+	if d <= 0 {
+		return nil, fmt.Errorf("%w: reclamation min_window must be > 0", errSDLInvalid)
+	}
+
+	return &dv1.DeploymentReclamation{MinWindow: d}, nil
+}

--- a/go/sdl/reclamation_test.go
+++ b/go/sdl/reclamation_test.go
@@ -1,0 +1,128 @@
+package sdl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestV2_Reclamation(t *testing.T) {
+	sdl, err := ReadFile("./_testdata/simple-reclamation.yaml")
+	require.NoError(t, err)
+
+	reclamation, err := sdl.Reclamation()
+	require.NoError(t, err)
+	require.NotNil(t, reclamation)
+	assert.Equal(t, 24*time.Hour, reclamation.MinWindow)
+}
+
+func TestV2_NoReclamation(t *testing.T) {
+	sdl, err := ReadFile("./_testdata/simple.yaml")
+	require.NoError(t, err)
+
+	reclamation, err := sdl.Reclamation()
+	require.NoError(t, err)
+	assert.Nil(t, reclamation)
+}
+
+func TestV2_1_Reclamation(t *testing.T) {
+	sdl, err := ReadFile("./_testdata/v2.1-simple-reclamation.yaml")
+	require.NoError(t, err)
+
+	reclamation, err := sdl.Reclamation()
+	require.NoError(t, err)
+	require.NotNil(t, reclamation)
+	assert.Equal(t, 24*time.Hour, reclamation.MinWindow)
+}
+
+func TestV2_1_NoReclamation(t *testing.T) {
+	sdl, err := ReadFile("./_testdata/v2.1-simple.yaml")
+	require.NoError(t, err)
+
+	reclamation, err := sdl.Reclamation()
+	require.NoError(t, err)
+	assert.Nil(t, reclamation)
+}
+
+func TestReclamation_InvalidDuration(t *testing.T) {
+	r := &v2Reclamation{MinWindow: "abc"}
+	_, err := r.toDeploymentReclamation()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestReclamation_ZeroDuration(t *testing.T) {
+	r := &v2Reclamation{MinWindow: "0s"}
+	_, err := r.toDeploymentReclamation()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestReclamation_NegativeDuration(t *testing.T) {
+	r := &v2Reclamation{MinWindow: "-1h"}
+	_, err := r.toDeploymentReclamation()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestReclamation_NilReceiver(t *testing.T) {
+	var r *v2Reclamation
+	result, err := r.toDeploymentReclamation()
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestV2_ReadFile_InvalidReclamation(t *testing.T) {
+	_, err := ReadFile("./_testdata/simple-reclamation-invalid.yaml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestV2_ReadFile_ZeroReclamation(t *testing.T) {
+	_, err := ReadFile("./_testdata/simple-reclamation-zero.yaml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestV2_1_ReadFile_InvalidReclamation(t *testing.T) {
+	_, err := ReadFile("./_testdata/v2.1-reclamation-invalid.yaml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestV2_1_ReadFile_ZeroReclamation(t *testing.T) {
+	_, err := ReadFile("./_testdata/v2.1-reclamation-zero.yaml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestReclamation_EmptyString(t *testing.T) {
+	r := &v2Reclamation{MinWindow: ""}
+	_, err := r.toDeploymentReclamation()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSDLInvalid)
+}
+
+func TestReclamation_ValidDurations(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"1h", 1 * time.Hour},
+		{"720h", 720 * time.Hour},
+		{"30m", 30 * time.Minute},
+		{"1h30m", 1*time.Hour + 30*time.Minute},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			r := &v2Reclamation{MinWindow: tc.input}
+			result, err := r.toDeploymentReclamation()
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tc.expected, result.MinWindow)
+		})
+	}
+}

--- a/go/sdl/sdl-input.schema.yaml
+++ b/go/sdl/sdl-input.schema.yaml
@@ -483,6 +483,23 @@ properties:
       additionalProperties: false
     type: object
 
+  reclamation:
+    description: >-
+      Deployment-level reclamation requirements (optional).
+      When set, providers must offer a reclamation window meeting or exceeding
+      the specified minimum to bid on this deployment.
+    additionalProperties: false
+    properties:
+      min_window:
+        type: string
+        description: >-
+          Minimum reclamation window duration the tenant requires.
+          Go duration format (e.g. "1h", "24h", "720h").
+        minLength: 1
+    required:
+      - min_window
+    type: object
+
   version:
     description: SDL version
     enum:

--- a/go/sdl/sdl.go
+++ b/go/sdl/sdl.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
+	dv1 "pkg.akt.dev/go/node/deployment/v1"
 	dtypes "pkg.akt.dev/go/node/deployment/v1beta4"
 )
 
@@ -26,6 +27,7 @@ type SDL interface {
 	DeploymentGroups() (dtypes.GroupSpecs, error)
 	Manifest() (manifest.Manifest, error)
 	Version() ([]byte, error)
+	Reclamation() (*dv1.DeploymentReclamation, error)
 	validate() error
 }
 
@@ -155,6 +157,14 @@ func (s *sdl) Manifest() (manifest.Manifest, error) {
 	}
 
 	return s.data.Manifest()
+}
+
+func (s *sdl) Reclamation() (*dv1.DeploymentReclamation, error) {
+	if s.data == nil {
+		return nil, errUninitializedConfig
+	}
+
+	return s.data.Reclamation()
 }
 
 func (s *sdl) validate() error {

--- a/go/sdl/v2.go
+++ b/go/sdl/v2.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
+	dv1 "pkg.akt.dev/go/node/deployment/v1"
 	dtypes "pkg.akt.dev/go/node/deployment/v1beta4"
 	types "pkg.akt.dev/go/node/types/attributes/v1"
 )
@@ -58,6 +59,7 @@ type v2 struct {
 	Profiles    v2profiles            `yaml:"profiles,omitempty"`
 	Deployments v2Deployments         `yaml:"deployment"`
 	Endpoints   map[string]v2Endpoint `yaml:"endpoints"`
+	ReclaimCfg  *v2Reclamation        `yaml:"-"`
 
 	result struct {
 		dgroups dtypes.GroupSpecs
@@ -244,6 +246,10 @@ func (sdl *v2) Version() ([]byte, error) {
 	return manifest.Manifest(sdl.result.mgroups).Version()
 }
 
+func (sdl *v2) Reclamation() (*dv1.DeploymentReclamation, error) {
+	return sdl.ReclaimCfg.toDeploymentReclamation()
+}
+
 func (sdl *v2) UnmarshalYAML(node *yaml.Node) error {
 	result := v2{}
 
@@ -261,6 +267,9 @@ loop:
 			val = &result.Deployments
 		case "endpoints":
 			val = &result.Endpoints
+		case "reclamation":
+			result.ReclaimCfg = &v2Reclamation{}
+			val = result.ReclaimCfg
 		case sdlVersionField:
 			// version is already verified
 			continue loop
@@ -283,6 +292,12 @@ loop:
 }
 
 func (sdl *v2) validate() error {
+	if sdl.ReclaimCfg != nil {
+		if _, err := sdl.ReclaimCfg.toDeploymentReclamation(); err != nil {
+			return err
+		}
+	}
+
 	for endpointName, endpoint := range sdl.Endpoints {
 		if !endpointNameValidationRegex.MatchString(endpointName) {
 			return fmt.Errorf(

--- a/go/sdl/v2_1.go
+++ b/go/sdl/v2_1.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
+	dv1 "pkg.akt.dev/go/node/deployment/v1"
 	dtypes "pkg.akt.dev/go/node/deployment/v1beta4"
 	types "pkg.akt.dev/go/node/types/attributes/v1"
 )
@@ -21,6 +22,7 @@ type v2_1 struct {
 	Profiles    v2profiles            `yaml:"profiles,omitempty"`
 	Deployments v2Deployments         `yaml:"deployment"`
 	Endpoints   map[string]v2Endpoint `yaml:"endpoints"`
+	ReclaimCfg  *v2Reclamation        `yaml:"-"`
 
 	result struct {
 		dgroups dtypes.GroupSpecs
@@ -41,6 +43,10 @@ func (sdl *v2_1) Version() ([]byte, error) {
 	return manifest.Manifest(sdl.result.mgroups).Version()
 }
 
+func (sdl *v2_1) Reclamation() (*dv1.DeploymentReclamation, error) {
+	return sdl.ReclaimCfg.toDeploymentReclamation()
+}
+
 func (sdl *v2_1) UnmarshalYAML(node *yaml.Node) error {
 	result := v2_1{}
 
@@ -58,6 +64,9 @@ loop:
 			val = &result.Deployments
 		case "endpoints":
 			val = &result.Endpoints
+		case "reclamation":
+			result.ReclaimCfg = &v2Reclamation{}
+			val = result.ReclaimCfg
 		case sdlVersionField:
 			// version is already verified
 			continue loop
@@ -80,6 +89,12 @@ loop:
 }
 
 func (sdl *v2_1) validate() error {
+	if sdl.ReclaimCfg != nil {
+		if _, err := sdl.ReclaimCfg.toDeploymentReclamation(); err != nil {
+			return err
+		}
+	}
+
 	for endpointName, endpoint := range sdl.Endpoints {
 		if !endpointNameValidationRegex.MatchString(endpointName) {
 			return fmt.Errorf(

--- a/go/util/events/publish.go
+++ b/go/util/events/publish.go
@@ -172,6 +172,7 @@ func processEvent(bev abci.Event) (interface{}, bool) {
 	case *mtypes.EventBidClosed:
 	case *mtypes.EventLeaseCreated:
 	case *mtypes.EventLeaseClosed:
+	case *mtypes.EventLeaseReclaimStarted:
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
Extend SDL with optional top-level `reclamation` block allowing tenants to specify a minimum reclamation window (e.g. `min_window: "24h"`). The parsed value populates MsgCreateDeployment.Reclamation. Add `--reclamation-window` flag to `tx market bid create` so providers can offer a reclamation window when bidding. Add new `tx market bid start-reclaim` command for providers to initiate reclamation on an active lease.
SDL changes:
- New v2Reclamation type with duration parsing and validation
- Reclamation() method added to SDL interface and all implementations
- Schema updated to accept optional reclamation property
- Validation in v2/v2_1 validate() rejects invalid durations at parse time CLI changes:
- deployment create wires SDL reclamation into MsgCreateDeployment
- bid create accepts --reclamation-window, sets MsgCreateBid.ReclamationWindow
- bid start-reclaim sends MsgLeaseStartReclaim with --reason flag

## 📝 Description
[Explain what this PR does in 2-3 sentences. Include context about the feature or problem being solved]

## 🔧 Purpose of the Change
- [x] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] I've updated relevant documentation
- [ ] Code follows Akash Network's style guide
- [ ] I've added/updated relevant unit tests
- [ ] Dependencies have been properly updated
- [ ] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
