### PR TITLE
chore(deps): bump akash cosmos sdk

### DIFF
--- a/go/cli/go.mod
+++ b/go/cli/go.mod
@@ -54,7 +54,7 @@ replace (
 	// use akash fork of cometbft
 	github.com/cometbft/cometbft => github.com/akash-network/cometbft v0.38.21-akash.1
 
-	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.5-akash.1
+	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.7-akash.2
 	// use akash version of cosmos ledger api
 	github.com/cosmos/ledger-cosmos-go => github.com/akash-network/ledger-go/cosmos v0.16.0
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -56,7 +56,7 @@ replace (
 	// use akash fork of cometbft
 	github.com/cometbft/cometbft => github.com/akash-network/cometbft v0.38.21-akash.1
 	// use akash fork of cosmos sdk
-	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.5-akash.1
+	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.7-akash.2
 
 	github.com/cosmos/gogoproto => github.com/akash-network/gogoproto v1.7.0-akash.2
 

--- a/go/sdl/go.mod
+++ b/go/sdl/go.mod
@@ -21,7 +21,7 @@ replace (
 	// use akash fork of cometbft
 	github.com/cometbft/cometbft => github.com/akash-network/cometbft v0.38.21-akash.1
 	// use akash fork of cosmos sdk
-	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.5-akash.1
+	github.com/cosmos/cosmos-sdk => github.com/akash-network/cosmos-sdk v0.53.7-akash.2
 
 	// Use regen gogoproto tag
 	// To be replaced by cosmos/gogoproto in future versions


### PR DESCRIPTION
## Summary

Bumps the Akash Cosmos SDK fork pointer to `v0.53.7-akash.2` across the
chain-sdk Go modules.

This picks up the bank denom metadata balance query fix from the Akash Cosmos
SDK fork.

Refs akash-network/support#556

## Changes

- `go/go.mod`
- `go/cli/go.mod`
- `go/sdl/go.mod`

Each module now points `github.com/cosmos/cosmos-sdk` at
`github.com/akash-network/cosmos-sdk v0.53.7-akash.2`.

No `go.sum` or other module graph changes are included.
