### PR TITLE
ci: fix golangci-lint cache install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ PROTOC_GEN_DOC_VERSION          := $(shell cd $(GO_ROOT); $(GO) list -mod=readon
 PROTOC_GEN_SWAGGER_VERSION      := $(PROTOC_GEN_GRPC_GATEWAY_VERSION)
 MODVENDOR_VERSION               ?= v0.5.0
 MOCKERY_VERSION                 ?= 2.52.2
-GOLANGCI_LINT_VERSION           ?= v2.3.0
+GOLANGCI_LINT_VERSION           ?= v2.12.2
 SEMVER_VERSION                  ?= v1.3.0
 
 BUF_VERSION_FILE                     := $(AKASH_DEVCACHE_VERSIONS)/buf/$(BUF_VERSION)

--- a/make/setup-cache.mk
+++ b/make/setup-cache.mk
@@ -152,18 +152,17 @@ $(MOCKERY_VERSION_FILE): $(AKASH_DEVCACHE)
 	touch $@
 $(MOCKERY): $(MOCKERY_VERSION_FILE)
 
-GOLANGCI_LINT_MAJOR=$(shell $(SEMVER) get major $(GOLANGCI_LINT_VERSION))
-
-$(GOLANGCI_LINT_VERSION_FILE): $(AP_DEVCACHE)
+$(GOLANGCI_LINT_VERSION_FILE): $(SEMVER) $(AKASH_DEVCACHE)
 	@echo "installing golangci-lint $(GOLANGCI_LINT_VERSION) ..."
-	rm -f $(MOCKERY)
+	rm -f $(GOLANGCI_LINT)
+	$(eval GOLANGCI_LINT_MAJOR := $(shell $(SEMVER) get major $(GOLANGCI_LINT_VERSION)))
 	(cd $(GO_ROOT); GOBIN=$(AKASH_DEVCACHE_BIN) go install github.com/golangci/golangci-lint/v$(GOLANGCI_LINT_MAJOR)/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 	rm -rf "$(dir $@)"
 	mkdir -p "$(dir $@)"
 	touch $@
 $(GOLANGCI_LINT): $(GOLANGCI_LINT_VERSION_FILE)
 
-$(SEMVER_VERSION_FILE): $(AP_DEVCACHE)
+$(SEMVER_VERSION_FILE): $(AKASH_DEVCACHE)
 	@echo "installing semver $(SEMVER_VERSION) ..."
 	rm -f $(SEMVER)
 	(cd $(GO_ROOT); GOBIN=$(AKASH_DEVCACHE_BIN) go install github.com/troian/semver/cmd/semver@$(SEMVER_VERSION))


### PR DESCRIPTION
## Summary
- Bump golangci-lint to v2.12.2.
- Install semver before deriving the golangci-lint major version.
- Fix the cache target to remove golangci-lint and depend on AKASH_DEVCACHE.

## Verification
- git diff --check
- direnv exec . bash -lc "GOTOOLCHAIN=go1.25.0 make lint-go"

This is intended to unblock the lint/go check on #318.