### PR TITLE
fix(ts): resolve grpc-gateway path field from {field=**} templates

### DIFF
--- a/ts/src/sdk/transport/grpc-gateway/createGrpcGatewayTransport.spec.ts
+++ b/ts/src/sdk/transport/grpc-gateway/createGrpcGatewayTransport.spec.ts
@@ -67,6 +67,33 @@ describe(createGrpcGatewayTransport.name, () => {
       expect(url.pathname).toBe("/users/123/resources/456");
     });
 
+    it("interpolates URL path with gRPC capture pattern ({field=**})", async () => {
+      const { transport, fetch, TestMethodSchema } = await setup();
+      const message = { userId: "123", resourceId: "456" };
+
+      Object.assign(TestMethodSchema, { httpPath: "/users/{userId=**}/resources/{resourceId}" });
+      fetch.mockResolvedValue(new Response(JSON.stringify({})));
+
+      await transport.unary(TestMethodSchema, message);
+
+      const url = fetch.mock.calls[0][0] as URL;
+      expect(url.pathname).toBe("/users/123/resources/456");
+    });
+
+    it("throws InvalidArgument naming the bare field when a {field=**} value is missing", async () => {
+      const { transport, TestMethodSchema } = await setup();
+      const message = { resourceId: "456" };
+
+      Object.assign(TestMethodSchema, { httpPath: "/users/{userId=**}" });
+
+      await expect(transport.unary(TestMethodSchema, message)).rejects.toThrow(
+        expect.objectContaining({
+          code: Code.InvalidArgument,
+          message: expect.not.stringContaining("=**"),
+        }),
+      );
+    });
+
     it("throws error when httpPath is missing", async () => {
       const { transport, TestMethodSchema } = await setup();
       const message = { test: "data" };

--- a/ts/src/sdk/transport/grpc-gateway/createGrpcGatewayTransport.ts
+++ b/ts/src/sdk/transport/grpc-gateway/createGrpcGatewayTransport.ts
@@ -53,7 +53,9 @@ export function createGrpcGatewayTransport(options: GrpcGatewayTransportOptions)
           requestMethod: method.httpMethod || "GET",
           url: method.httpPath.replace(/\{[^}]+\}/g, (interpolation) => {
             const data = message as Record<string, unknown> | undefined;
-            const key = interpolation.slice(1, -1).trim();
+            // gRPC path templates may carry a capture pattern ({denom=**}, {name=segments});
+            // the message field is the FieldPath before "="
+            const key = interpolation.slice(1, -1).split("=")[0].trim();
             if (!data || !Object.hasOwn(data, key)) {
               throw new TransportError(`Cannot construct url for ${method.parent.typeName}.${method.name}: "${key}" is not specified in message`, TransportError.Code.InvalidArgument);
             }


### PR DESCRIPTION
## 📝 Description
The grpc-gateway transport's URL builder treated the entire `{...}` interior of a path template as the message field name. For gRPC capture templates like `/akash/oracle/v2/aggregated_price/{denom=**}` it looked up a field literally named `denom=**`, failed, and threw `TransportError [invalid_argument]` **client-side, before any request**. This fix strips the `=pattern` suffix so the FieldPath before `=` is used.

## 🔧 Purpose of the Change
- [x] Bug fix

## 📌 Related Issues
- Downstream blocker: akash-network/console#3268 (CON-195) — Oracle V1→V2 migration

## ✅ Checklist
- [ ] I've updated relevant documentation
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [ ] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
**The fix** (one line in `createGrpcGatewayTransport.ts`): `interpolation.slice(1,-1).trim()` → `interpolation.slice(1,-1).split("=")[0].trim()`. `{denom}` is unchanged; `{denom=**}` now resolves to `denom`.

**Blast radius** — every `{field=**}` query was broken, not just oracle v2:
- `akash/oracle/v2` — `aggregated_price/{denom=**}`
- `cosmos/bank/v1beta1` — `denoms_metadata/{denom=**}`, `denom_owners/{denom=**}`
- `ibc/apps/transfer/v1` — `denoms/{hash=**}`, `denom_hashes/{trace=**}`, `total_escrow/{denom=**}`

All capture patterns in the generated code are the single-field greedy form `{field=**}` — no nested `{a.b.c}` or `{field=collection/*}` — so stripping the suffix covers every case.

**Verification:** unit tests added to `createGrpcGatewayTransport.spec.ts`; also drove the actual generated oracle v2/v1 methods through the transport (V2 `{denom=**}` → `/akash/oracle/v2/aggregated_price/akt`, no throw; V1 `{denom}` regression intact). The redundant query param that GET serialization emits (`?denom=akt`) is pre-existing behavior matching V1 and is tolerated by the live node (verified against mainnet V1, identical URL shape).

**Out of scope** (possible follow-ups): stripping path-bound fields from the GET query string; full path-template support (nested FieldPaths, `**`-aware slash-preserving encoding).
