### PR TITLE
fix(manifest): wrap resource validation errors with ErrInvalidManifest

### DIFF
--- a/go/manifest/v2beta3/manifest_test.go
+++ b/go/manifest/v2beta3/manifest_test.go
@@ -467,3 +467,60 @@ func Test_ValidateManifest(t *testing.T) {
 		}
 	}
 }
+
+// Test_ValidateManifest_ResourceErrorsWrapped ensures that resource validation
+// failures surfaced while validating a manifest are wrapped with
+// ErrInvalidManifest, so that consumers (e.g. the provider gateway) can classify
+// them as client errors rather than returning a 500.
+func Test_ValidateManifest_ResourceErrorsWrapped(t *testing.T) {
+	const (
+		testHost  = "host.test"
+		testImage = "test-image"
+	)
+
+	expose := make([]ServiceExpose, 1)
+	expose[0].Global = true
+	expose[0].Port = 80
+	expose[0].Proto = TCP
+	expose[0].Hosts = []string{testHost}
+
+	newManifest := func(mutate func(r *resources.Resources)) Manifest {
+		res := simpleResources(expose)
+		mutate(&res)
+
+		return Manifest{
+			{
+				Name: nameOfTestGroup,
+				Services: []Service{
+					{
+						Name:      nameOfTestService,
+						Image:     testImage,
+						Resources: res,
+						Count:     1,
+						Expose:    expose,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(r *resources.Resources)
+		wantMsg string
+	}{
+		{"nil CPU", func(r *resources.Resources) { r.CPU = nil }, "CPU must not be nil"},
+		{"nil GPU", func(r *resources.Resources) { r.GPU = nil }, "GPU must not be nil"},
+		{"nil memory", func(r *resources.Resources) { r.Memory = nil }, "memory must not be nil"},
+		{"nil storage", func(r *resources.Resources) { r.Storage = nil }, "storage must not be nil"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := newManifest(test.mutate).Validate()
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrInvalidManifest)
+			require.ErrorContains(t, err, test.wantMsg)
+		})
+	}
+}

--- a/go/manifest/v2beta3/service.go
+++ b/go/manifest/v2beta3/service.go
@@ -25,7 +25,7 @@ func (s *Service) validate(helper *validateManifestGroupsHelper) error {
 	}
 
 	if err := s.Resources.Validate(); err != nil {
-		return err
+		return fmt.Errorf("%w: service %q: %w", ErrInvalidManifest, s.Name, err)
 	}
 
 	for _, envVar := range s.Env {


### PR DESCRIPTION
## Summary

`Service.validate` returned the error from `Resources.Validate()` **unwrapped**, unlike every other validation failure in that function (which are tagged with `ErrInvalidManifest`).

Consumers that classify manifest errors by sentinel — notably the Akash provider gateway, which maps `ErrInvalidManifest` to **HTTP 422** — could not recognise these errors and fell back to **HTTP 500**. For example, a manifest with a nil GPU produced `"GPU must not be nil"`, which surfaced to users as a server error (and the console proxy then reported a misleading 503).

## Change

Wrap the resource validation error with `ErrInvalidManifest`, matching the surrounding validation code, so it is correctly classified as a client error.

```go
if err := s.Resources.Validate(); err != nil {
    return fmt.Errorf("%w: service %q: %w", ErrInvalidManifest, s.Name, err)
}
```

## Tests

Added `Test_ValidateManifest_ResourceErrorsWrapped` covering nil CPU/GPU/Memory/Storage, asserting the error from `Manifest.Validate()` wraps `ErrInvalidManifest`. Verified the test fails without the fix and passes with it. `go test`, `gofmt`, `go vet` and `golangci-lint` (repo config) are clean.

refs: akash-network/support#421