### PR TITLE
fix(events): publish FinalizeBlock events, not just tx events

### DIFF
--- a/go/util/events/publish.go
+++ b/go/util/events/publish.go
@@ -141,14 +141,34 @@ func (e *events) processBlock(height int64) {
 			continue
 		}
 
-		for _, ev := range tx.Events {
-			if mev, ok := processEvent(ev); ok {
-				if err := e.bus.Publish(mev); err != nil {
-					return
-				}
-			}
+		if !e.publishEvents(tx.Events) {
+			return
 		}
 	}
+
+	// Events emitted from BeginBlock/EndBlock (e.g. a lease closed by escrow
+	// depletion in the escrow module's EndBlocker) are not part of any
+	// transaction and surface in FinalizeBlockEvents. Process them too, or
+	// such closes never reach the bus and the resources are never reclaimed.
+	e.publishEvents(blkResults.FinalizeBlockEvents)
+}
+
+// publishEvents runs each event through processEvent and publishes the ones it
+// recognizes. It returns false if publishing failed, signalling the caller to
+// stop processing the current block.
+func (e *events) publishEvents(evs []abci.Event) bool {
+	for _, ev := range evs {
+		mev, ok := processEvent(ev)
+		if !ok {
+			continue
+		}
+
+		if err := e.bus.Publish(mev); err != nil {
+			return false
+		}
+	}
+
+	return true
 }
 
 func processEvent(bev abci.Event) (interface{}, bool) {

--- a/go/util/events/publish_test.go
+++ b/go/util/events/publish_test.go
@@ -1,50 +1,81 @@
 package events
 
-// import (
-// 	"testing"
-//
-// 	sdk "github.com/cosmos/cosmos-sdk/types"
-// 	"github.com/stretchr/testify/assert"
-//
-// 	dtypes "pkg.akt.dev/go/node/deployment/v1"
-// 	mtypes "pkg.akt.dev/go/node/market/v1beta5"
-// 	ptypes "pkg.akt.dev/go/node/provider/v1beta4"
-// 	"pkg.akt.dev/go/sdkutil"
-//
-// 	"pkg.akt.dev/node/testutil"
-// )
-//
-// func Test_processEvent(t *testing.T) {
-// 	tests := []sdkutil.ModuleEvent{
-// 		// x/deployment events
-// 		dtypes.NewEventDeploymentCreated(testutil.DeploymentID(t), testutil.DeploymentVersion(t)),
-// 		dtypes.NewEventDeploymentUpdated(testutil.DeploymentID(t), testutil.DeploymentVersion(t)),
-// 		dtypes.NewEventDeploymentClosed(testutil.DeploymentID(t)),
-// 		dtypes.NewEventGroupClosed(testutil.GroupID(t)),
-//
-// 		// x/market events
-// 		mtypes.NewEventOrderCreated(testutil.OrderID(t)),
-// 		mtypes.NewEventOrderClosed(testutil.OrderID(t)),
-// 		mtypes.NewEventBidCreated(testutil.BidID(t), testutil.DecCoin(t)),
-// 		mtypes.NewEventBidClosed(testutil.BidID(t), testutil.DecCoin(t)),
-// 		mtypes.NewEventLeaseCreated(testutil.LeaseID(t), testutil.DecCoin(t)),
-// 		mtypes.NewEventLeaseClosed(testutil.LeaseID(t), testutil.DecCoin(t)),
-//
-// 		// x/provider events
-// 		ptypes.NewEventProviderCreated(testutil.AccAddress(t)),
-// 		ptypes.NewEventProviderUpdated(testutil.AccAddress(t)),
-// 		ptypes.NewEventProviderDeleted(testutil.AccAddress(t)),
-// 	}
-//
-// 	for _, test := range tests {
-// 		sdkevs := sdk.Events{
-// 			test.ToSDKEvent(),
-// 		}.ToABCIEvents()
-//
-// 		sdkev := sdkevs[0]
-//
-// 		ev, ok := processEvent(sdkev)
-// 		assert.True(t, ok, test)
-// 		assert.Equal(t, test, ev, test)
-// 	}
-// }
+import (
+	"context"
+	"testing"
+	"time"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/stretchr/testify/require"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	mtypes "pkg.akt.dev/go/node/market/v1"
+	"pkg.akt.dev/go/util/pubsub"
+)
+
+// blockResultsClient is a minimal CometRPC stub that returns canned block
+// results so processBlock can be exercised without a live node.
+type blockResultsClient struct {
+	sdkclient.CometRPC
+	results *ctypes.ResultBlockResults
+}
+
+func (c *blockResultsClient) BlockResults(_ context.Context, _ *int64) (*ctypes.ResultBlockResults, error) {
+	return c.results, nil
+}
+
+func leaseClosedABCIEvent(t *testing.T, owner string) abci.Event {
+	t.Helper()
+	ev, err := sdk.TypedEventToEvent(&mtypes.EventLeaseClosed{
+		ID: mtypes.LeaseID{Owner: owner, DSeq: 1, GSeq: 1, OSeq: 1, Provider: "akash1provider"},
+	})
+	require.NoError(t, err)
+	return abci.Event(ev)
+}
+
+// Test_processBlock_FinalizeBlockEvents guards the #515 fix: a lease closed in
+// an EndBlocker (e.g. escrow depletion) surfaces in FinalizeBlockEvents with no
+// associated transaction, and must still reach the bus.
+func Test_processBlock_FinalizeBlockEvents(t *testing.T) {
+	bus := pubsub.NewBus()
+	defer bus.Close()
+
+	sub, err := bus.Subscribe()
+	require.NoError(t, err)
+
+	e := &events{
+		ctx: context.Background(),
+		bus: bus,
+		client: &blockResultsClient{
+			results: &ctypes.ResultBlockResults{
+				Height: 1,
+				// a tx-initiated close (must still be published)
+				TxsResults: []*abci.ExecTxResult{
+					{Events: []abci.Event{leaseClosedABCIEvent(t, "akash1txowner")}},
+				},
+				// an EndBlock close (escrow depletion) — previously dropped
+				FinalizeBlockEvents: []abci.Event{leaseClosedABCIEvent(t, "akash1endblockowner")},
+			},
+		},
+	}
+
+	e.processBlock(1)
+
+	owners := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case ev := <-sub.Events():
+			lc, ok := ev.(*mtypes.EventLeaseClosed)
+			require.True(t, ok, "expected EventLeaseClosed, got %T", ev)
+			owners[lc.ID.Owner] = true
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for published events, got %d", len(owners))
+		}
+	}
+
+	require.True(t, owners["akash1txowner"], "tx-initiated lease close must be published")
+	require.True(t, owners["akash1endblockowner"], "EndBlock (escrow-depletion) lease close must be published")
+}


### PR DESCRIPTION
### What

`processBlock` only iterated `blkResults.TxsResults`, so events emitted from `BeginBlock`/`EndBlock` (which surface in `FinalizeBlockEvents` on CometBFT 0.38) were silently dropped. This also runs `FinalizeBlockEvents` through the same `processEvent`/`Publish` path.

### Why

A lease closed by **escrow depletion** is closed in the escrow module's `EndBlocker` with no associated transaction, so its `EventLeaseClosed` lived only in `FinalizeBlockEvents` and never reached the bus. The provider's cluster teardown is driven exclusively by that event, so escrow-closed leases were never reclaimed - the Kubernetes namespace and `manifest` CR persisted indefinitely while `deployment-monitor` looped `ok=false`. After AEP-76 this turned into a fleet-wide capacity leak.

`processEvent` already handles the typed close events (`EventLeaseClosed`, `EventOrderClosed`, `EventBidClosed`); they simply were never fed the block-level events.

### Testing

Added `Test_processBlock_FinalizeBlockEvents`: a stub `CometRPC` returns an `EventLeaseClosed` in `FinalizeBlockEvents` (escrow-style close) alongside one in `TxsResults` (tx-style close), and the test asserts **both** reach the bus. Fails without the fix.

refs: akash-network/support#515