### PR TITLE
fix(ts): automatically adds tee/type attribute to group-spec when params.tee is specified

### DIFF
--- a/ts/src/sdk/client/sdkMetadata.ts
+++ b/ts/src/sdk/client/sdkMetadata.ts
@@ -1,7 +1,7 @@
 import type { ServiceLoader } from "./createServiceLoader.ts";
 import type { ServiceDesc } from "./types.ts";
 
-const SDK_METHOD_METADATA = new Map<SDKMethod, SDKMethodMetadata>();
+const SDK_METHOD_METADATA = new WeakMap<SDKMethod, SDKMethodMetadata>();
 export function withMetadata<T extends SDKMethod>(fn: T, metadata: SDKMethodMetadata): T {
   SDK_METHOD_METADATA.set(fn, metadata);
   return fn;

--- a/ts/src/sdl/manifest/generateManifest.spec.ts
+++ b/ts/src/sdl/manifest/generateManifest.spec.ts
@@ -236,6 +236,203 @@ describe(generateManifest.name, () => {
 
       expect(result.groups[0].services[0].params?.tee).toBeUndefined();
     });
+
+    it("projects tee cpu as a sorted tee/type group-spec requirement attribute", () => {
+      const sdl = createBasicSdl({ placementAttributes: { region: "us-west", zone: "z1" } });
+      sdl.services.web.params = { tee: "cpu" };
+      const { result } = setup({ sdl });
+
+      const attributes = result.groupSpecs[0].requirements?.attributes;
+      expect(attributes).toContainEqual({ key: "tee/type", value: "cpu" });
+      // attributes stay sorted by key (canonical on-chain ordering); tee/type
+      // sorts between region and zone.
+      expect(attributes?.map((a) => a.key)).toEqual(["region", "tee/type", "zone"]);
+    });
+
+    it("projects tee cpu-gpu as a tee/type group-spec requirement attribute", () => {
+      const sdl = createBasicSdl({
+        gpu: { units: 1, attributes: { vendor: { nvidia: [{ model: "a100" }] } } },
+      });
+      sdl.services.web.params = { tee: "cpu-gpu" };
+      const { result } = setup({ sdl });
+
+      expect(result.groupSpecs[0].requirements?.attributes).toContainEqual({ key: "tee/type", value: "cpu-gpu" });
+    });
+
+    it("adds no tee/type attribute when tee is not set", () => {
+      const sdl = createBasicSdl({ placementAttributes: { region: "us-west" } });
+      const { result } = setup({ sdl });
+
+      const attributes = result.groupSpecs[0].requirements?.attributes ?? [];
+      expect(attributes.some((a) => a.key === "tee/type")).toBe(false);
+    });
+
+    it("rejects conflicting tee types within the same placement group", () => {
+      const sdl: SDLInput = yaml`
+        version: "2.1"
+        services:
+          alpha:
+            image: nginx
+            expose:
+              - port: 80
+                as: 80
+                to:
+                  - global: true
+            params:
+              tee: cpu
+          beta:
+            image: nginx
+            expose:
+              - port: 81
+                as: 81
+                to:
+                  - global: true
+            params:
+              tee: cpu-gpu
+        profiles:
+          compute:
+            alpha:
+              resources:
+                cpu:
+                  units: 0.5
+                memory:
+                  size: 512Mi
+                storage:
+                  size: 512Mi
+            beta:
+              resources:
+                cpu:
+                  units: 0.5
+                memory:
+                  size: 512Mi
+                storage:
+                  size: 512Mi
+                gpu:
+                  units: 1
+                  attributes:
+                    vendor:
+                      nvidia:
+                        - model: a100
+          placement:
+            dcloud:
+              pricing:
+                alpha:
+                  denom: uakt
+                  amount: 1000
+                beta:
+                  denom: uakt
+                  amount: 1000
+        deployment:
+          alpha:
+            dcloud:
+              profile: alpha
+              count: 1
+          beta:
+            dcloud:
+              profile: beta
+              count: 1
+      `;
+
+      const result = generateManifest(sdl);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.value).toContainEqual(expect.objectContaining({
+          instancePath: "/services/beta/params/tee",
+          keyword: "tee",
+          message: expect.stringContaining("conflicting tee types"),
+        }));
+      }
+    });
+
+    it("emits a single tee/type attribute for two same-tee services sharing a group", () => {
+      const sdl: SDLInput = yaml`
+        version: "2.1"
+        services:
+          alpha:
+            image: nginx
+            expose:
+              - port: 80
+                as: 80
+                to:
+                  - global: true
+            params:
+              tee: cpu
+          beta:
+            image: nginx
+            expose:
+              - port: 81
+                as: 81
+                to:
+                  - global: true
+            params:
+              tee: cpu
+        profiles:
+          compute:
+            alpha:
+              resources:
+                cpu:
+                  units: 0.5
+                memory:
+                  size: 512Mi
+                storage:
+                  size: 512Mi
+            beta:
+              resources:
+                cpu:
+                  units: 0.5
+                memory:
+                  size: 512Mi
+                storage:
+                  size: 512Mi
+          placement:
+            dcloud:
+              pricing:
+                alpha:
+                  denom: uakt
+                  amount: 1000
+                beta:
+                  denom: uakt
+                  amount: 1000
+        deployment:
+          alpha:
+            dcloud:
+              profile: alpha
+              count: 1
+          beta:
+            dcloud:
+              profile: beta
+              count: 1
+      `;
+      const { result } = setup({ sdl });
+
+      const teeAttributes = (result.groupSpecs[0].requirements?.attributes ?? []).filter((a) => a.key === "tee/type");
+      expect(teeAttributes).toEqual([{ key: "tee/type", value: "cpu" }]);
+    });
+
+    // Cross-check the projected group-spec attributes against the Go parser's
+    // golden output for the shared TEE parity fixtures (generated by
+    // `make generate-sdl-fixtures`). This locks bit-for-bit parity with
+    // go/sdl/groupBuilder_v2_1.go's `tee/type` projection.
+    describe("Go parser parity (group-spec attributes)", () => {
+      const TESTDATA_ROOT = path.join(__dirname, "../../../../testdata/sdl");
+
+      it.each([
+        ["tee-cpu", "cpu"],
+        ["tee-cpu-gpu", "cpu-gpu"],
+      ])("matches Go group-spec requirement attributes for the %s fixture", (fixture, teeType) => {
+        const input = fs.readFileSync(path.join(TESTDATA_ROOT, "input/v2.1", fixture, "input.yaml"), "utf8");
+        const sdl = yaml.raw<SDLInput>(input);
+        const { result } = setup({ sdl });
+
+        const golden = JSON.parse(
+          fs.readFileSync(path.join(TESTDATA_ROOT, "output-fixtures/v2.1", fixture, "group-specs.json"), "utf8"),
+        );
+
+        expect(result.groupSpecs).toHaveLength(golden.length);
+        expect(result.groupSpecs[0].requirements?.attributes).toEqual(golden[0].requirements.attributes);
+        expect(result.groupSpecs[0].requirements?.attributes).toContainEqual({ key: "tee/type", value: teeType });
+      });
+    });
   });
 
   describe("storage configuration", () => {

--- a/ts/src/sdl/manifest/generateManifest.ts
+++ b/ts/src/sdl/manifest/generateManifest.ts
@@ -50,6 +50,7 @@ export function generateManifest(sdl: SDLInput): GenerateManifestResult {
   const groupsMap = new Map<string, {
     dgroup: GroupSpec;
     boundComputes: Record<string, number>;
+    teeType?: string;
   }>();
   const resourceIds = new Map<string, number>();
 
@@ -96,9 +97,17 @@ export function generateManifest(sdl: SDLInput): GenerateManifestResult {
             }),
           }),
           boundComputes: {},
+          teeType: undefined,
         };
 
         groupsMap.set(placementName, group);
+      }
+
+      const teeType = service.params?.tee;
+      if (teeType && !group.teeType) {
+        group.teeType = teeType;
+        group.dgroup.requirements!.attributes.push({ key: "tee/type", value: teeType });
+        group.dgroup.requirements!.attributes.sort((a, b) => a.key.localeCompare(b.key));
       }
 
       const profileKey = `${placementName}:${svcdepl.profile}`;

--- a/ts/src/sdl/validateSDL/validateSDL.spec.ts
+++ b/ts/src/sdl/validateSDL/validateSDL.spec.ts
@@ -685,6 +685,102 @@ describe(validateSDL.name, () => {
 
       expect(validate()).toBeUndefined();
     });
+
+    it("returns an error when two services in the same placement group declare conflicting tee types", () => {
+      const { validate } = setup({
+        services: {
+          web: { params: { tee: "cpu" } },
+          gpuapp: {
+            image: "nginx:latest",
+            expose: [{ port: 81, as: 81, to: [{ global: true }] }],
+            params: { tee: "cpu-gpu" },
+          },
+        },
+        profiles: {
+          compute: {
+            gpuapp: {
+              resources: {
+                cpu: { units: 1 },
+                memory: { size: "512Mi" },
+                storage: { size: "1Gi" },
+                gpu: { units: 1, attributes: { vendor: { nvidia: [] } } },
+              },
+            },
+          },
+          placement: {
+            dcloud: { pricing: { gpuapp: { amount: "1000", denom: AKT_DENOM } } },
+          },
+        },
+        deployment: {
+          gpuapp: { dcloud: { count: 1, profile: "gpuapp" } },
+        },
+      });
+
+      expect(validate()).toContainEqual(expect.objectContaining({
+        message: expect.stringContaining(`conflicting tee types in placement group "dcloud"`),
+        instancePath: "/services/gpuapp/params/tee",
+        keyword: "tee",
+      }));
+    });
+
+    it("accepts two services in the same placement group sharing a tee type", () => {
+      const { validate } = setup({
+        services: {
+          web: { params: { tee: "cpu" } },
+          worker: {
+            image: "nginx:latest",
+            expose: [{ port: 81, as: 81, to: [{ global: true }] }],
+            params: { tee: "cpu" },
+          },
+        },
+        profiles: {
+          compute: {
+            worker: { resources: { cpu: { units: 1 }, memory: { size: "512Mi" }, storage: { size: "1Gi" } } },
+          },
+          placement: {
+            dcloud: { pricing: { worker: { amount: "1000", denom: AKT_DENOM } } },
+          },
+        },
+        deployment: {
+          worker: { dcloud: { count: 1, profile: "worker" } },
+        },
+      });
+
+      expect(validate()).toBeUndefined();
+    });
+
+    it("accepts conflicting tee types across different placement groups", () => {
+      const { validate } = setup({
+        services: {
+          web: { params: { tee: "cpu" } },
+          gpuapp: {
+            image: "nginx:latest",
+            expose: [{ port: 81, as: 81, to: [{ global: true }] }],
+            params: { tee: "cpu-gpu" },
+          },
+        },
+        profiles: {
+          compute: {
+            gpuapp: {
+              resources: {
+                cpu: { units: 1 },
+                memory: { size: "512Mi" },
+                storage: { size: "1Gi" },
+                gpu: { units: 1, attributes: { vendor: { nvidia: [] } } },
+              },
+            },
+          },
+          placement: {
+            dcloud2: { pricing: { gpuapp: { amount: "1000", denom: AKT_DENOM } } },
+          },
+        },
+        deployment: {
+          gpuapp: { dcloud2: { count: 1, profile: "gpuapp" } },
+        },
+      });
+
+      expect(validate()).toBeUndefined();
+    });
   });
 
   describe("IP lease validation", () => {

--- a/ts/src/sdl/validateSDL/validateSDL.ts
+++ b/ts/src/sdl/validateSDL/validateSDL.ts
@@ -36,6 +36,7 @@ export function validateSDL(sdl: SDLInput): undefined | ValidationError[] {
 class SDLValidator {
   readonly #endpointsUsed = new Set<string>();
   readonly #portsUsed = new Map<string, string>();
+  readonly #teeTypeByPlacement = new Map<string, string>();
   readonly #sdl: SDLInput;
   readonly #errors: ValidationError[] = [];
 
@@ -260,27 +261,50 @@ class SDLValidator {
     }
   }
 
-  // Mirrors Go `validateTEEWithGPU` (go/sdl/tee.go): the `cpu-gpu` TEE type
-  // requires GPU resources on the resolved compute profile. `cpu` (and absent)
-  // need no GPU. Unsupported tee values are rejected structurally by the input
-  // schema (`tee` enum in validateSDLInput.ts) before this runs.
+  // Mirrors Go's TEE rules from `buildGroups` (go/sdl/groupBuilder_v2.go:58-83,
+  // groupBuilder_v2_1.go:59-84). Two checks, both on `deploymentName` (the
+  // placement-group name):
+  //   1. `validateTEEWithGPU` — the `cpu-gpu` type requires GPU resources on the
+  //      resolved compute profile (`cpu`/absent need none).
+  //   2. `errTEETypeMismatch` — a placementg diff group may carry only one tee type,
+  //      since `generateManifest` projects it as a single `tee/type` requirement
+  //      attribute. Detecting the conflict here (the validation layer) means
+  //      standalone `validateSDL` callers catch it, and `generateManifest` can
+  //      project unconditionally.
+  // Unsupported tee values are rejected structurally by the input schema (`tee`
+  // enum in validateSDLInput.ts) before this runs.
   #validateTEE(serviceName: string, deploymentName: string) {
     const tee = this.#sdl.services?.[serviceName]?.params?.tee;
-    if (tee !== "cpu-gpu") return;
+    if (!tee) return;
 
-    const profile = this.#sdl.deployment[serviceName]?.[deploymentName]?.profile;
-    const gpu = this.#sdl.profiles?.compute?.[profile]?.resources.gpu;
-    const hasGpu = gpu?.units !== undefined && gpu.units !== 0;
+    if (tee === "cpu-gpu") {
+      const profile = this.#sdl.deployment[serviceName]?.[deploymentName]?.profile;
+      const gpu = this.#sdl.profiles?.compute?.[profile]?.resources.gpu;
+      const hasGpu = gpu?.units !== undefined && gpu.units !== 0;
 
-    if (!hasGpu) {
+      if (!hasGpu) {
+        this.#errors.push({
+          message: `Service "${serviceName}" tee type requires gpu resources.`,
+          instancePath: `/services/${serviceName}/params/tee`,
+          schemaPath: "#/properties/services/additionalProperties/properties/params/properties/tee",
+          keyword: "required",
+          params: {
+            missingProperty: "gpu",
+          },
+        });
+      }
+    }
+
+    const existing = this.#teeTypeByPlacement.get(deploymentName);
+    if (existing === undefined) {
+      this.#teeTypeByPlacement.set(deploymentName, tee);
+    } else if (existing !== tee) {
       this.#errors.push({
-        message: `Service "${serviceName}" tee type requires gpu resources.`,
+        message: `conflicting tee types in placement group "${deploymentName}": "${existing}" and "${tee}"`,
         instancePath: `/services/${serviceName}/params/tee`,
         schemaPath: "#/properties/services/additionalProperties/properties/params/properties/tee",
-        keyword: "required",
-        params: {
-          missingProperty: "gpu",
-        },
+        keyword: "tee",
+        params: {},
       });
     }
   }


### PR DESCRIPTION
## 📝 Description

1. Automatically adds `tee/type` attribute to GroupSpec when `params.tee` is specified
2. Validate that all services inside one placement have the same TEE type
3. fixes memory leak related to storing method metadata of SDK clients

## 🔧 Purpose of the Change
- [ ] New feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- Closes #ISSUE_NUMBER
- References #ISSUE_NUMBER

## ✅ Checklist
- [ ] ~I've updated relevant documentation~
- [x] Code follows Akash Network's style guide
- [x] I've added/updated relevant unit tests
- [x] Dependencies have been properly updated
- [x] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/chain-sdk/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers
[Include any additional context, architectural decisions, or specific areas to focus on]
